### PR TITLE
feat: wire Redis/OIDC staff auth and local testing setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,5 +84,29 @@ VITE_APP_NAME="${APP_NAME}"
 # CLOUDRON_LDAP_GROUPS_BASE_DN, CLOUDRON_LDAP_BIND_DN,
 # CLOUDRON_LDAP_BIND_PASSWORD
 # CLOUDRON_OIDC_DISCOVERY_URL, CLOUDRON_OIDC_ISSUER,
-# CLOUDRON_OIDC_CLIENT_ID, CLOUDRON_OIDC_CLIENT_SECRET
+# CLOUDRON_OIDC_CLIENT_ID, CLOUDRON_OIDC_CLIENT_SECRET,
+# CLOUDRON_OIDC_PROVIDER_NAME
 # CLOUDRON_APP_ORIGIN, CLOUDRON_PROXY_IP
+#
+# --- Local production-like testing (optional) ---------------------------
+# Uncomment to test Redis/OIDC/LDAP locally. See docs/local-dev.md.
+# Requires: docker compose up -d redis (and optionally openldap)
+#
+# CACHE_STORE=redis
+# QUEUE_CONNECTION=redis
+# SESSION_DRIVER=redis
+# REDIS_CLIENT=predis
+# REDIS_HOST=127.0.0.1
+# REDIS_PORT=6379
+#
+# CLOUDRON_OIDC_DISCOVERY_URL=https://<cloudron-domain>/.well-known/openid-configuration
+# CLOUDRON_OIDC_ISSUER=https://<cloudron-domain>
+# CLOUDRON_OIDC_CLIENT_ID=<localhost-oidc-client-id>
+# CLOUDRON_OIDC_CLIENT_SECRET=<localhost-oidc-client-secret>
+# CLOUDRON_OIDC_PROVIDER_NAME=Cloudron
+#
+# CLOUDRON_LDAP_URL=ldap://127.0.0.1:389
+# CLOUDRON_LDAP_USERS_BASE_DN=ou=users,dc=apes,dc=local
+# CLOUDRON_LDAP_GROUPS_BASE_DN=ou=groups,dc=apes,dc=local
+# CLOUDRON_LDAP_BIND_DN=cn=admin,dc=apes,dc=local
+# CLOUDRON_LDAP_BIND_PASSWORD=admin

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ php artisan serve
 ```
 
 No MySQL or Redis needed for local dev - `.env.example` defaults to
-sqlite, database-backed sessions/cache/queue. In Cloudron,
-`CloudronEnvironmentServiceProvider` (`app/Providers`) overrides these
-from the platform's `CLOUDRON_*` environment variables automatically; see
+sqlite, database-backed sessions/cache/queue. For production-like local
+testing with Redis and OIDC, see [`docs/local-dev.md`](docs/local-dev.md).
+In Cloudron, `CloudronEnvironmentServiceProvider` (`app/Providers`) overrides
+these from the platform's `CLOUDRON_*` environment variables automatically; see
 that file and `.env.example` for what's mapped.
 
 ## Testing

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -14,7 +14,14 @@ class AuthenticatedSessionController extends Controller
 {
     public function create(): Response
     {
-        return Inertia::render('Auth/Login');
+        $discoveryUrl = config('services.cloudron_oidc.discovery_url');
+
+        return Inertia::render('Auth/Login', [
+            'staffLoginUrl' => $discoveryUrl ? route('cloudron.redirect') : null,
+            'staffLoginLabel' => $discoveryUrl
+                ? 'Log in with '.config('services.cloudron_oidc.provider_name')
+                : null,
+        ]);
     }
 
     public function store(LoginRequest $request): RedirectResponse

--- a/app/Providers/CloudronEnvironmentServiceProvider.php
+++ b/app/Providers/CloudronEnvironmentServiceProvider.php
@@ -126,6 +126,10 @@ class CloudronEnvironmentServiceProvider extends ServiceProvider
         Config::set('services.cloudron_oidc.issuer', $this->cloudronEnv('CLOUDRON_OIDC_ISSUER'));
         Config::set('services.cloudron_oidc.client_id', $this->cloudronEnv('CLOUDRON_OIDC_CLIENT_ID'));
         Config::set('services.cloudron_oidc.client_secret', $this->cloudronEnv('CLOUDRON_OIDC_CLIENT_SECRET'));
+
+        if ($providerName = $this->cloudronEnv('CLOUDRON_OIDC_PROVIDER_NAME')) {
+            Config::set('services.cloudron_oidc.provider_name', $providerName);
+        }
     }
 
     private function mapLdap(): void
@@ -138,6 +142,10 @@ class CloudronEnvironmentServiceProvider extends ServiceProvider
         Config::set('ldap.connections.default.username', $this->cloudronEnv('CLOUDRON_LDAP_BIND_DN'));
         Config::set('ldap.connections.default.password', $this->cloudronEnv('CLOUDRON_LDAP_BIND_PASSWORD'));
         Config::set('ldap.connections.default.base_dn', $this->cloudronEnv('CLOUDRON_LDAP_USERS_BASE_DN'));
-        Config::set('services.cloudron_oidc.ldap_groups_base_dn', $this->cloudronEnv('CLOUDRON_LDAP_GROUPS_BASE_DN'));
+        Config::set('services.cloudron_ldap.url', $this->cloudronEnv('CLOUDRON_LDAP_URL'));
+        Config::set('services.cloudron_ldap.users_base_dn', $this->cloudronEnv('CLOUDRON_LDAP_USERS_BASE_DN'));
+        Config::set('services.cloudron_ldap.groups_base_dn', $this->cloudronEnv('CLOUDRON_LDAP_GROUPS_BASE_DN'));
+        Config::set('services.cloudron_ldap.bind_dn', $this->cloudronEnv('CLOUDRON_LDAP_BIND_DN'));
+        Config::set('services.cloudron_ldap.bind_password', $this->cloudronEnv('CLOUDRON_LDAP_BIND_PASSWORD'));
     }
 }

--- a/app/Services/Auth/LdapGroupLookup.php
+++ b/app/Services/Auth/LdapGroupLookup.php
@@ -7,44 +7,51 @@ use LdapRecord\Container;
 use Throwable;
 
 /**
- * Looks up the LDAP group DNs a staff member belongs to.
+ * Looks up the LDAP groups a staff member belongs to.
  *
+ * Cloudron LDAP exposes group membership on the user entry via the
+ * `memberof` attribute rather than a `member` filter on group entries.
  * This is a thin, mockable wrapper around LdapRecord so StaffReconciler's
- * fail-closed logic can be unit-tested without a real directory (via a
- * test double implementing this same interface, or LdapRecord's
- * DirectoryEmulator bound to the 'default' connection).
+ * fail-closed logic can be unit-tested without a real directory.
  */
 class LdapGroupLookup
 {
     /**
-     * Return the DNs of every group under the configured groups base DN
-     * that lists the given member DN.
+     * Return the group identifiers (CN or DN) for the user with the given email.
      *
      * @return array<int, string>
      *
      * @throws LdapUnreachableException when the directory cannot be reached or searched.
      */
-    public function groupsForMember(string $memberDn): array
+    public function groupsForEmail(string $email): array
     {
-        $baseDn = config('services.cloudron_oidc.ldap_groups_base_dn');
+        $usersBaseDn = config('services.cloudron_ldap.users_base_dn')
+            ?? config('ldap.connections.default.base_dn');
 
-        if (! $baseDn) {
-            throw new LdapUnreachableException('LDAP groups base DN is not configured.');
+        if (! $usersBaseDn) {
+            throw new LdapUnreachableException('LDAP users base DN is not configured.');
         }
 
         try {
             $results = Container::getConnection('default')
                 ->query()
-                ->in($baseDn)
-                ->where('member', '=', $memberDn)
+                ->in($usersBaseDn)
+                ->where('mail', '=', $email)
                 ->get();
         } catch (Throwable $e) {
             throw new LdapUnreachableException('Unable to query LDAP for group membership: '.$e->getMessage(), previous: $e);
         }
 
-        return array_map(
-            fn (array $entry) => is_array($entry['dn'] ?? null) ? $entry['dn'][0] : $entry['dn'],
-            $results,
-        );
+        if ($results === []) {
+            return [];
+        }
+
+        $memberof = $results[0]['memberof'] ?? [];
+
+        if (! is_array($memberof)) {
+            return $memberof !== '' && $memberof !== null ? [(string) $memberof] : [];
+        }
+
+        return array_values(array_map('strval', $memberof));
     }
 }

--- a/app/Services/Auth/StaffReconciler.php
+++ b/app/Services/Auth/StaffReconciler.php
@@ -21,7 +21,7 @@ class StaffReconciler
     public function reconcile(StaffOidcIdentity $identity): StaffReconcileResult
     {
         try {
-            $groups = $this->ldap->groupsForMember($identity->sub);
+            $groups = $this->ldap->groupsForEmail($identity->email);
         } catch (LdapUnreachableException) {
             return StaffReconcileResult::deny(
                 'Staff sign-in failed: directory is currently unreachable. Please try again shortly.'

--- a/config/rbac.php
+++ b/config/rbac.php
@@ -9,21 +9,23 @@ return [
     | LDAP group to role mapping
     |--------------------------------------------------------------------
     |
-    | Maps Cloudron LDAP group distinguished names (or CNs, depending on
-    | what CLOUDRON_LDAP_GROUPS_BASE_DN search returns) to application
-    | Role values. This is a best guess pending real Cloudron group names
-    | (see docs/epic-1-build-plan.md issue #4) - expect a config-only
-    | follow-up once the real directory is available, not a code change.
+    | Maps Cloudron LDAP group identifiers to application Role values.
+    | Keys must match the values returned in each user's `memberof`
+    | attribute exactly (case-insensitive) — run the ldapsearch command
+    | in docs/deployment.md to discover the real group names after
+    | creating groups in Cloudron.
     |
-    | Only groups listed here are recognised. Any staff member whose
-    | groups do not intersect this map is denied login (fail closed) -
-    | see App\Services\Auth\StaffReconciler.
+    | Cloudron may return either a group CN (e.g. `newsroom-staff`) or a
+    | full DN — include whichever format your directory returns. Only
+    | groups listed here are recognised. Any staff member whose groups do
+    | not intersect this map is denied login (fail closed) — see
+    | App\Services\Auth\StaffReconciler.
     |
     */
     'ldap_group_map' => [
-        'cn=newsroom-staff,ou=groups,dc=apes,dc=org,dc=uk' => Role::Staff,
-        'cn=newsroom-admins,ou=groups,dc=apes,dc=org,dc=uk' => Role::Admin,
-        'cn=newsroom-super-admins,ou=groups,dc=apes,dc=org,dc=uk' => Role::SuperAdmin,
+        'newsroom-staff' => Role::Staff,
+        'newsroom-admins' => Role::Admin,
+        'newsroom-super-admins' => Role::SuperAdmin,
     ],
 
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -42,7 +42,7 @@ return [
     |
     | Read directly from the CLOUDRON_LDAP_* environment variables Cloudron
     | injects for the LDAP addon (docs.cloudron.io/packaging/addons#ldap).
-    | Consumed by staff role reconciliation (issue #4) - not wired up yet.
+    | Consumed by staff role reconciliation via LdapGroupLookup.
     | Values are absent outside Cloudron; group mapping happens in code,
     | not here, so no group names are hard-coded to a config value.
     |
@@ -63,8 +63,9 @@ return [
     |
     | Read from the CLOUDRON_OIDC_* environment variables Cloudron injects
     | for the manually-registered OIDC client (docs.cloudron.io/packaging/
-    | addons#oidc). Consumed by staff authentication (issue #4) - not wired
-    | up yet.
+    | addons#oidc). On LAMP apps, create the client in the Cloudron
+    | dashboard and set these in /app/data/shared/.env — see
+    | docs/deployment.md.
     |
     */
 
@@ -73,6 +74,7 @@ return [
         'issuer' => env('CLOUDRON_OIDC_ISSUER'),
         'client_id' => env('CLOUDRON_OIDC_CLIENT_ID'),
         'client_secret' => env('CLOUDRON_OIDC_CLIENT_SECRET'),
+        'provider_name' => env('CLOUDRON_OIDC_PROVIDER_NAME', 'Cloudron'),
     ],
 
 ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+# Optional local services for production-like development.
+# Not used by CI or Cloudron deploys.
+#
+#   docker compose up -d redis          # Redis only (most common)
+#   docker compose up -d                # Redis + OpenLDAP
+#   docker compose down
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+  openldap:
+    image: osixia/openldap:1.5.0
+    ports:
+      - "389:389"
+    environment:
+      LDAP_ORGANISATION: APES
+      LDAP_DOMAIN: apes.local
+      LDAP_ADMIN_PASSWORD: admin
+    volumes:
+      - ./docker/openldap/bootstrap.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/bootstrap.ldif

--- a/docker/openldap/bootstrap.ldif
+++ b/docker/openldap/bootstrap.ldif
@@ -1,0 +1,49 @@
+# Test users and groups for local OpenLDAP (docker compose openldap service).
+# Group CNs must match keys in config/rbac.php.
+
+dn: ou=users,dc=apes,dc=local
+objectClass: organizationalUnit
+ou: users
+
+dn: ou=groups,dc=apes,dc=local
+objectClass: organizationalUnit
+ou: groups
+
+dn: cn=newsroom-staff,ou=groups,dc=apes,dc=local
+objectClass: groupOfNames
+cn: newsroom-staff
+member: cn=staffer,ou=users,dc=apes,dc=local
+
+dn: cn=newsroom-admins,ou=groups,dc=apes,dc=local
+objectClass: groupOfNames
+cn: newsroom-admins
+member: cn=admin,ou=users,dc=apes,dc=local
+
+dn: cn=newsroom-super-admins,ou=groups,dc=apes,dc=local
+objectClass: groupOfNames
+cn: newsroom-super-admins
+member: cn=superadmin,ou=users,dc=apes,dc=local
+
+dn: cn=staffer,ou=users,dc=apes,dc=local
+objectClass: inetOrgPerson
+cn: Staffer Person
+sn: Person
+uid: staffer
+mail: staffer@apes.local
+userPassword: staffer
+
+dn: cn=admin,ou=users,dc=apes,dc=local
+objectClass: inetOrgPerson
+cn: Admin Person
+sn: Person
+uid: admin
+mail: admin@apes.local
+userPassword: admin
+
+dn: cn=superadmin,ou=users,dc=apes,dc=local
+objectClass: inetOrgPerson
+cn: Super Admin
+sn: Admin
+uid: superadmin
+mail: superadmin@apes.local
+userPassword: superadmin

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -144,3 +144,83 @@ Production (`apesnews.org.uk`) deployment is a separate, later workflow
 gated on issue #11's beta acceptance and explicit production
 authorization - it doesn't exist yet, on purpose. This pipeline only ever
 touches beta.
+
+## Redis addon
+
+Enable Redis in the Cloudron dashboard for this LAMP app, then restart.
+Cloudron injects `CLOUDRON_REDIS_*` at runtime; `CloudronEnvironmentServiceProvider`
+switches cache, queue, and sessions to Redis automatically.
+
+**Verify after restart:**
+
+```bash
+cloudron exec --app 74a2a784-a161-4787-84ff-2b8efc957bc8 -- printenv | grep CLOUDRON_REDIS
+curl https://beta.apesnews.org.uk/health
+```
+
+Expected: `"cache": true` in the health response.
+
+Ensure `/app/data/run.sh` exists (copy from `deploy/cloudron-run.sh`) so
+the queue worker starts on boot against the Redis-backed queue.
+
+## OIDC client (staff sign-in)
+
+LAMP apps do **not** auto-inject OIDC credentials. Create an OpenID
+client manually in the Cloudron dashboard:
+
+1. **Users & Groups → OpenID Clients → Add Client**
+2. **Redirect URI (beta):** `https://beta.apesnews.org.uk/auth/cloudron/callback`
+3. Scopes: `openid`, `email`, `profile`
+4. Note the client ID, client secret, and Cloudron domain
+
+Add to `/app/data/shared/.env` (never commit):
+
+```env
+CLOUDRON_OIDC_DISCOVERY_URL=https://<cloudron-domain>/.well-known/openid-configuration
+CLOUDRON_OIDC_ISSUER=https://<cloudron-domain>
+CLOUDRON_OIDC_CLIENT_ID=<client-id>
+CLOUDRON_OIDC_CLIENT_SECRET=<client-secret>
+CLOUDRON_OIDC_PROVIDER_NAME=Cloudron
+```
+
+Restart the app and run `php artisan config:cache` inside the container.
+The login page shows a staff sign-in button once `CLOUDRON_OIDC_DISCOVERY_URL`
+is set.
+
+For local development, create a **second** client with redirect URI
+`http://localhost:8000/auth/cloudron/callback` — see
+[`docs/local-dev.md`](local-dev.md).
+
+## LDAP group mapping
+
+Staff roles are derived from each user's `memberof` attribute in Cloudron
+LDAP. Group names must match keys in `config/rbac.php`.
+
+**Discover group names** inside the Cloudron container:
+
+```bash
+cloudron exec --app 74a2a784-a161-4787-84ff-2b8efc957bc8 -- bash -c \
+  'ldapsearch -x -H "$CLOUDRON_LDAP_URL" -D "$CLOUDRON_LDAP_BIND_DN" -w "$CLOUDRON_LDAP_BIND_PASSWORD" -b "$CLOUDRON_LDAP_GROUPS_BASE_DN" cn'
+```
+
+**Inspect a user's `memberof`:**
+
+```bash
+cloudron exec --app 74a2a784-a161-4787-84ff-2b8efc957bc8 -- bash -c \
+  'ldapsearch -x -H "$CLOUDRON_LDAP_URL" -D "$CLOUDRON_LDAP_BIND_DN" -w "$CLOUDRON_LDAP_BIND_PASSWORD" -b "$CLOUDRON_LDAP_USERS_BASE_DN" "(mail=<user-email>)" memberof'
+```
+
+Update `config/rbac.php` so keys match the `memberof` values exactly
+(case-insensitive). Deploy the updated config to beta.
+
+## End-to-end verification (beta)
+
+| Check | Expected |
+|-------|----------|
+| `GET /health` | `"cache": true`, `"database": true` |
+| `deploy:preflight --target=beta` | Redis reachable |
+| Visit `/login` | Staff sign-in button visible |
+| Staff sign-in | Redirect to Cloudron OIDC |
+| Login as group member | User created with correct role |
+| Login as non-member | Denied on login page |
+| Queue worker | Processing jobs via Redis |

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,138 @@
+# Local development
+
+Two modes: **default** (zero extra services) and **production-like**
+(Redis, OIDC, LDAP). Everyday feature work and CI use the default.
+
+## Default setup
+
+```
+composer install
+cp .env.example .env
+php artisan key:generate
+php artisan migrate
+npm install
+composer dev    # or: php artisan serve + npm run dev
+```
+
+Uses SQLite with database-backed sessions, cache, and queue. No Docker
+required.
+
+## Production-like setup
+
+Use this to verify Redis drivers, staff OIDC login, and LDAP role mapping
+before deploying to beta.
+
+### 1. Start optional services
+
+```bash
+docker compose up -d redis          # Redis only (most common)
+docker compose up -d                # Redis + OpenLDAP
+docker compose down
+```
+
+OpenLDAP is seeded from `docker/openldap/bootstrap.ldif` with test users
+and groups matching `config/rbac.php`.
+
+### 2. Configure `.env`
+
+Copy the commented block at the bottom of `.env.example` into your local
+`.env` and uncomment the values you need.
+
+**Redis:**
+
+```env
+CACHE_STORE=redis
+QUEUE_CONNECTION=redis
+SESSION_DRIVER=redis
+REDIS_CLIENT=predis
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379
+```
+
+Use `predis` on Windows if the PHP `redis` extension is not installed.
+Cloudron uses `phpredis`.
+
+**OIDC (Cloudron client for localhost):**
+
+Create a **second** OpenID client in the Cloudron dashboard:
+
+- Redirect URI: `http://localhost:8000/auth/cloudron/callback`
+
+```env
+APP_URL=http://localhost:8000
+CLOUDRON_OIDC_DISCOVERY_URL=https://<cloudron-domain>/.well-known/openid-configuration
+CLOUDRON_OIDC_ISSUER=https://<cloudron-domain>
+CLOUDRON_OIDC_CLIENT_ID=<localhost-client-id>
+CLOUDRON_OIDC_CLIENT_SECRET=<localhost-client-secret>
+CLOUDRON_OIDC_PROVIDER_NAME=Cloudron
+```
+
+**LDAP — option A: Cloudron directory**
+
+Copy `CLOUDRON_LDAP_*` values from Cloudron `/app/data/credentials.txt`
+into `.env`. Requires network access to the Cloudron LDAP host.
+
+**LDAP — option B: Docker OpenLDAP**
+
+```env
+CLOUDRON_LDAP_URL=ldap://127.0.0.1:389
+CLOUDRON_LDAP_USERS_BASE_DN=ou=users,dc=apes,dc=local
+CLOUDRON_LDAP_GROUPS_BASE_DN=ou=groups,dc=apes,dc=local
+CLOUDRON_LDAP_BIND_DN=cn=admin,dc=apes,dc=local
+CLOUDRON_LDAP_BIND_PASSWORD=admin
+```
+
+Test users (password = username): `staffer@apes.local`, `admin@apes.local`,
+`superadmin@apes.local`.
+
+### 3. Run the app
+
+```bash
+# Terminal 1
+composer dev
+
+# Terminal 2 (required when QUEUE_CONNECTION=redis)
+php artisan queue:work
+```
+
+### 4. Verify
+
+```bash
+php artisan deploy:preflight
+curl http://localhost:8000/health
+```
+
+Expected health response when Redis is configured:
+
+```json
+{"status":"ok","checks":{"database":true,"cache":true}}
+```
+
+**Staff OIDC flow:**
+
+1. Visit `http://localhost:8000/login`
+2. Click the staff sign-in button
+3. Authenticate at Cloudron OIDC
+4. Callback reconciles LDAP groups and stores the session in Redis
+
+## Automated tests
+
+PHPUnit covers auth logic without live services:
+
+```bash
+composer test
+```
+
+`StaffOidcLoginTest` mocks LDAP lookup. `LdapGroupLookupTest` uses
+LdapRecord's directory emulator. `LoginPageTest` verifies the staff
+button appears only when OIDC is configured.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `cache: false` on `/health` | Redis not running or wrong host | `docker compose up -d redis`; check `REDIS_HOST` |
+| OIDC redirect mismatch | Wrong redirect URI on client | Register exact callback URL in Cloudron dashboard |
+| Staff login denied (no group) | `memberof` values don't match `config/rbac.php` | Run ldapsearch (see `docs/deployment.md`) and update keys |
+| LDAP connection timeout | Cloudron LDAP not reachable locally | Use Docker OpenLDAP (option B) |
+| Queue jobs not processing | Worker not running | Start `php artisan queue:work` in a second terminal |

--- a/resources/js/Pages/Auth/Login.tsx
+++ b/resources/js/Pages/Auth/Login.tsx
@@ -1,7 +1,12 @@
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
 
-export default function Login() {
+interface LoginProps {
+    staffLoginUrl: string | null;
+    staffLoginLabel: string | null;
+}
+
+export default function Login({ staffLoginUrl, staffLoginLabel }: LoginProps) {
     const { data, setData, post, processing, errors, reset } = useForm({
         email: '',
         password: '',
@@ -20,6 +25,17 @@ export default function Login() {
             <Head title="Log in" />
             <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6">
                 <h1 className="text-2xl font-semibold text-neutral-900">Log in</h1>
+                {staffLoginUrl && (
+                    <div className="flex flex-col gap-2">
+                        <a
+                            href={staffLoginUrl}
+                            className="rounded border border-neutral-300 px-4 py-2 text-center text-sm font-medium text-neutral-900 hover:bg-neutral-50"
+                        >
+                            {staffLoginLabel ?? 'Staff sign in'}
+                        </a>
+                        <p className="text-center text-xs text-neutral-500">or use a public account below</p>
+                    </div>
+                )}
                 <form onSubmit={submit} className="flex flex-col gap-4">
                     <div>
                         <label htmlFor="email">Email</label>

--- a/tests/Feature/Auth/LdapGroupLookupTest.php
+++ b/tests/Feature/Auth/LdapGroupLookupTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Services\Auth\LdapGroupLookup;
+use LdapRecord\Laravel\Testing\DirectoryEmulator;
+use LdapRecord\Models\Entry;
+use Tests\TestCase;
+
+class LdapGroupLookupTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DirectoryEmulator::setup('default');
+
+        config([
+            'ldap.connections.default.base_dn' => 'dc=apes,dc=local',
+            'services.cloudron_ldap.users_base_dn' => 'ou=users,dc=apes,dc=local',
+        ]);
+    }
+
+    public function test_returns_memberof_groups_for_a_matching_user_email(): void
+    {
+        $groupDn = 'cn=newsroom-staff,ou=groups,dc=apes,dc=local';
+
+        Entry::create([
+            'dn' => $groupDn,
+            'objectclass' => ['groupOfNames'],
+            'cn' => 'newsroom-staff',
+        ]);
+
+        Entry::create([
+            'dn' => 'cn=staffer,ou=users,dc=apes,dc=local',
+            'objectclass' => ['inetOrgPerson'],
+            'cn' => 'Staffer Person',
+            'uid' => 'staffer',
+            'mail' => 'staffer@example.com',
+            'memberof' => [$groupDn],
+        ]);
+
+        $groups = (new LdapGroupLookup)->groupsForEmail('staffer@example.com');
+
+        $this->assertSame([$groupDn], $groups);
+    }
+
+    public function test_returns_empty_array_when_no_user_matches_the_email(): void
+    {
+        $groups = (new LdapGroupLookup)->groupsForEmail('nobody@example.com');
+
+        $this->assertSame([], $groups);
+    }
+}

--- a/tests/Feature/Auth/LoginPageTest.php
+++ b/tests/Feature/Auth/LoginPageTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class LoginPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_login_page_hides_staff_sign_in_when_oidc_is_not_configured(): void
+    {
+        config(['services.cloudron_oidc.discovery_url' => null]);
+
+        $this->get(route('login'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Auth/Login')
+                ->where('staffLoginUrl', null)
+            );
+    }
+
+    public function test_login_page_shows_staff_sign_in_when_oidc_is_configured(): void
+    {
+        config(['services.cloudron_oidc.discovery_url' => 'https://cloudron.example/.well-known/openid-configuration']);
+
+        $this->get(route('login'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Auth/Login')
+                ->where('staffLoginUrl', route('cloudron.redirect'))
+            );
+    }
+}

--- a/tests/Feature/Auth/StaffOidcLoginTest.php
+++ b/tests/Feature/Auth/StaffOidcLoginTest.php
@@ -16,11 +16,11 @@ class StaffOidcLoginTest extends TestCase
 {
     use RefreshDatabase;
 
-    private const STAFF_GROUP = 'cn=newsroom-staff,ou=groups,dc=apes,dc=org,dc=uk';
+    private const STAFF_GROUP = 'newsroom-staff';
 
-    private const ADMIN_GROUP = 'cn=newsroom-admins,ou=groups,dc=apes,dc=org,dc=uk';
+    private const ADMIN_GROUP = 'newsroom-admins';
 
-    private const SUPER_ADMIN_GROUP = 'cn=newsroom-super-admins,ou=groups,dc=apes,dc=org,dc=uk';
+    private const SUPER_ADMIN_GROUP = 'newsroom-super-admins';
 
     private function identity(string $sub = 'oidc-sub-1'): StaffOidcIdentity
     {
@@ -30,7 +30,7 @@ class StaffOidcLoginTest extends TestCase
     private function reconcilerWithGroups(array $groups): StaffReconciler
     {
         $lookup = Mockery::mock(LdapGroupLookup::class);
-        $lookup->shouldReceive('groupsForMember')->andReturn($groups);
+        $lookup->shouldReceive('groupsForEmail')->andReturn($groups);
 
         return new StaffReconciler($lookup);
     }
@@ -38,7 +38,7 @@ class StaffOidcLoginTest extends TestCase
     private function reconcilerThatFails(): StaffReconciler
     {
         $lookup = Mockery::mock(LdapGroupLookup::class);
-        $lookup->shouldReceive('groupsForMember')->andThrow(new LdapUnreachableException('down'));
+        $lookup->shouldReceive('groupsForEmail')->andThrow(new LdapUnreachableException('down'));
 
         return new StaffReconciler($lookup);
     }


### PR DESCRIPTION
Enable Cloudron-compatible LDAP group lookup, staff sign-in UI, and documentation/docker tooling for production-like local development.