### PR TITLE
feat: epic phase 1-2 — auth, design, publishing, and public newsroom

### DIFF
--- a/app/Console/Commands/PublishScheduledPostsCommand.php
+++ b/app/Console/Commands/PublishScheduledPostsCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\PostStatus;
+use App\Models\Post;
+use Illuminate\Console\Command;
+
+class PublishScheduledPostsCommand extends Command
+{
+    protected $signature = 'posts:publish-scheduled';
+
+    protected $description = 'Publish posts whose scheduled_for time has passed (Europe/London)';
+
+    public function handle(): int
+    {
+        $posts = Post::query()
+            ->where('status', PostStatus::Scheduled)
+            ->whereNotNull('scheduled_for')
+            ->where('scheduled_for', '<=', now('Europe/London'))
+            ->get();
+
+        foreach ($posts as $post) {
+            $post->update([
+                'status' => PostStatus::Published,
+                'published_at' => $post->scheduled_for,
+                'scheduled_for' => null,
+            ]);
+
+            $this->line("Published: {$post->title}");
+        }
+
+        $this->info("Published {$posts->count()} scheduled post(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ReconcileStaffRolesCommand.php
+++ b/app/Console/Commands/ReconcileStaffRolesCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\Role;
+use App\Exceptions\Auth\LdapUnreachableException;
+use App\Models\User;
+use App\Services\Auth\LdapGroupLookup;
+use Illuminate\Console\Command;
+
+/**
+ * Scheduled safety reconciliation for Cloudron staff accounts (issue #4).
+ *
+ * Re-queries LDAP group membership for every staff user and downgrades
+ * or demotes accounts whose directory membership no longer matches.
+ */
+class ReconcileStaffRolesCommand extends Command
+{
+    protected $signature = 'staff:reconcile-roles';
+
+    protected $description = 'Reconcile Cloudron staff roles from current LDAP group membership';
+
+    public function handle(LdapGroupLookup $ldap): int
+    {
+        $staffUsers = User::query()
+            ->where('auth_provider', 'cloudron_oidc')
+            ->whereNotNull('external_id')
+            ->get();
+
+        $map = collect(config('rbac.ldap_group_map', []))
+            ->mapWithKeys(fn (Role $role, string $group) => [mb_strtolower($group) => $role]);
+
+        $updated = 0;
+        $demoted = 0;
+
+        foreach ($staffUsers as $user) {
+            try {
+                $groups = $ldap->groupsForEmail($user->email);
+            } catch (LdapUnreachableException $e) {
+                $this->warn("LDAP unreachable; skipping {$user->email}");
+
+                continue;
+            }
+
+            $matchedRoles = collect($groups)
+                ->map(fn (string $group) => $map->get(mb_strtolower($group)))
+                ->filter()
+                ->values();
+
+            if ($matchedRoles->isEmpty()) {
+                $user->forceFill([
+                    'role' => Role::Public,
+                    'ldap_group_snapshot' => $groups,
+                ])->save();
+
+                $demoted++;
+                $this->line("Demoted {$user->email} — no recognised LDAP groups");
+
+                continue;
+            }
+
+            $role = $matchedRoles->sortByDesc(fn (Role $role) => $role->rank())->first();
+
+            if ($user->role !== $role || $user->ldap_group_snapshot !== $groups) {
+                $user->forceFill([
+                    'role' => $role,
+                    'ldap_group_snapshot' => $groups,
+                ])->save();
+
+                $updated++;
+                $this->line("Updated {$user->email} → {$role->value}");
+            }
+        }
+
+        $this->info("Reconciliation complete: {$updated} updated, {$demoted} demoted.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Enums/Channel.php
+++ b/app/Enums/Channel.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Enums;
+
+enum Channel: string
+{
+    case ApesCic = 'apes_cic';
+    case ApesShelterRescue = 'apes_shelter_rescue';
+    case ApesPetCareClinic = 'apes_pet_care_clinic';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ApesCic => 'APES CIC',
+            self::ApesShelterRescue => 'APES Shelter & Rescue',
+            self::ApesPetCareClinic => 'APES Pet Care Clinic',
+        };
+    }
+
+    public function slug(): string
+    {
+        return match ($this) {
+            self::ApesCic => 'apes-cic',
+            self::ApesShelterRescue => 'apes-shelter-rescue',
+            self::ApesPetCareClinic => 'apes-pet-care-clinic',
+        };
+    }
+
+    public static function fromSlug(string $slug): ?self
+    {
+        return collect(self::cases())->first(fn (self $c) => $c->slug() === $slug);
+    }
+}

--- a/app/Enums/PostStatus.php
+++ b/app/Enums/PostStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+enum PostStatus: string
+{
+    case Draft = 'draft';
+    case InReview = 'in_review';
+    case Scheduled = 'scheduled';
+    case Published = 'published';
+    case Unpublished = 'unpublished';
+    case Deleted = 'deleted';
+
+    public function isPubliclyVisible(): bool
+    {
+        return $this === self::Published;
+    }
+}

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdateAccountRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class AccountController extends Controller
+{
+    public function show(Request $request): Response
+    {
+        return Inertia::render('Account/Profile', [
+            'user' => $request->user()->only(['name', 'email', 'role', 'auth_provider']),
+            'status' => session('status'),
+        ]);
+    }
+
+    public function update(UpdateAccountRequest $request): RedirectResponse
+    {
+        $user = $request->user();
+        $validated = $request->validated();
+
+        if ($validated['email'] !== $user->email) {
+            $validated['email_verified_at'] = null;
+        }
+
+        $user->update($validated);
+
+        if ($user->wasChanged('email')) {
+            $user->sendEmailVerificationNotification();
+        }
+
+        return back()->with('status', 'profile-updated');
+    }
+
+    public function export(Request $request): StreamedResponse
+    {
+        $user = $request->user();
+
+        $payload = [
+            'exported_at' => now()->toIso8601String(),
+            'account' => [
+                'name' => $user->name,
+                'email' => $user->email,
+                'role' => $user->role->value,
+                'auth_provider' => $user->auth_provider,
+                'email_verified_at' => $user->email_verified_at?->toIso8601String(),
+                'created_at' => $user->created_at?->toIso8601String(),
+            ],
+        ];
+
+        $filename = 'apes-newsroom-account-'.now()->format('Y-m-d').'.json';
+
+        return response()->streamDownload(
+            fn () => print (json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)),
+            $filename,
+            ['Content-Type' => 'application/json'],
+        );
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        Auth::logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        $user->delete();
+
+        return redirect()->route('home');
+    }
+}

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use App\Services\EditorJs\BlockRenderer;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ArticleController extends Controller
+{
+    public function show(string $slug, BlockRenderer $renderer): Response
+    {
+        $post = Post::published()
+            ->where('slug', $slug)
+            ->with('author', 'tags')
+            ->firstOrFail();
+
+        return Inertia::render('Articles/Show', [
+            'article' => [
+                'title' => $post->title,
+                'slug' => $post->slug,
+                'excerpt' => $post->excerpt,
+                'html' => $renderer->toHtml($post->content),
+                'channel' => $post->channel->label(),
+                'channel_slug' => $post->channel->slug(),
+                'author' => $post->author->name,
+                'published_at' => $post->published_at?->toIso8601String(),
+                'meta_title' => $post->meta_title ?? $post->title,
+                'meta_description' => $post->meta_description ?? $post->excerpt,
+                'tags' => $post->tags->pluck('name'),
+            ],
+            'preview' => false,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Auth/EmailVerificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class EmailVerificationController extends Controller
+{
+    public function notice(Request $request): Response|RedirectResponse
+    {
+        if ($request->user()?->hasVerifiedEmail()) {
+            return redirect()->route('account.show');
+        }
+
+        return Inertia::render('Auth/VerifyEmail', [
+            'status' => session('status'),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        if ($request->user()->hasVerifiedEmail()) {
+            return redirect()->route('account.show');
+        }
+
+        $request->user()->sendEmailVerificationNotification();
+
+        return back()->with('status', 'verification-link-sent');
+    }
+
+    public function verify(EmailVerificationRequest $request): RedirectResponse
+    {
+        if ($request->user()->hasVerifiedEmail()) {
+            return redirect()->route('account.show');
+        }
+
+        if ($request->user()->markEmailAsVerified()) {
+            event(new Verified($request->user()));
+        }
+
+        return redirect()->route('account.show')->with('status', 'email-verified');
+    }
+
+}

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -37,6 +37,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($user);
 
-        return redirect()->route('home');
+        return redirect()->route('verification.notice');
     }
 }

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\Channel;
+use App\Models\Post;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ChannelController extends Controller
+{
+    public function show(string $channel): Response
+    {
+        $channelEnum = Channel::fromSlug($channel);
+
+        if (! $channelEnum) {
+            abort(404);
+        }
+
+        $posts = Post::published()
+            ->where('channel', $channelEnum)
+            ->with('author')
+            ->latest('published_at')
+            ->paginate(12)
+            ->through(fn (Post $post) => [
+                'title' => $post->title,
+                'slug' => $post->slug,
+                'excerpt' => $post->excerpt,
+                'author' => $post->author->name,
+                'published_at' => $post->published_at?->toIso8601String(),
+            ]);
+
+        return Inertia::render('Channels/Show', [
+            'channel' => [
+                'slug' => $channelEnum->slug(),
+                'label' => $channelEnum->label(),
+            ],
+            'posts' => $posts,
+        ]);
+    }
+}

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\Channel;
+use App\Models\Post;
+use App\Services\EditorJs\BlockRenderer;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class HomeController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $posts = Post::published()
+            ->with('author')
+            ->latest('published_at')
+            ->limit(12)
+            ->get()
+            ->map(fn (Post $post) => $this->cardPayload($post));
+
+        $featured = $posts->first();
+
+        return Inertia::render('home', [
+            'featured' => $featured,
+            'recent' => $posts->skip(1)->values(),
+            'channels' => collect(Channel::cases())->map(fn (Channel $c) => [
+                'slug' => $c->slug(),
+                'label' => $c->label(),
+            ]),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function cardPayload(Post $post): array
+    {
+        return [
+            'title' => $post->title,
+            'slug' => $post->slug,
+            'excerpt' => $post->excerpt,
+            'channel' => $post->channel->label(),
+            'channel_slug' => $post->channel->slug(),
+            'author' => $post->author->name,
+            'published_at' => $post->published_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Controllers/RssController.php
+++ b/app/Http/Controllers/RssController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use Illuminate\Http\Response;
+
+class RssController extends Controller
+{
+    public function index(): Response
+    {
+        $posts = Post::published()->with('author')->latest('published_at')->limit(50)->get();
+
+        $xml = view('rss', ['posts' => $posts])->render();
+
+        return response($xml, 200, ['Content-Type' => 'application/rss+xml']);
+    }
+}

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SearchController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $query = (string) $request->query('q', '');
+
+        $posts = collect();
+
+        if ($query !== '') {
+            $posts = Post::published()
+                ->where(function ($q) use ($query) {
+                    $q->where('title', 'like', "%{$query}%")
+                        ->orWhere('excerpt', 'like', "%{$query}%");
+                })
+                ->latest('published_at')
+                ->limit(20)
+                ->get()
+                ->map(fn (Post $post) => [
+                    'title' => $post->title,
+                    'slug' => $post->slug,
+                    'excerpt' => $post->excerpt,
+                    'published_at' => $post->published_at?->toIso8601String(),
+                ]);
+        }
+
+        return Inertia::render('Search/Index', [
+            'query' => $query,
+            'results' => $posts,
+        ]);
+    }
+}

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use Illuminate\Http\Response;
+
+class SitemapController extends Controller
+{
+    public function index(): Response
+    {
+        $posts = Post::published()->orderByDesc('published_at')->get(['slug', 'updated_at', 'published_at']);
+
+        $xml = view('sitemap', ['posts' => $posts])->render();
+
+        return response($xml, 200, ['Content-Type' => 'application/xml']);
+    }
+}

--- a/app/Http/Controllers/Staff/PostController.php
+++ b/app/Http/Controllers/Staff/PostController.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Http\Controllers\Staff;
+
+use App\Enums\Channel;
+use App\Enums\PostStatus;
+use App\Enums\Role;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Staff\StorePostRequest;
+use App\Http\Requests\Staff\UpdatePostRequest;
+use App\Models\Post;
+use App\Models\PostRevision;
+use App\Services\EditorJs\BlockRenderer;
+use App\Services\EditorJs\BlockValidator;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PostController extends Controller
+{
+    public function __construct(
+        private readonly BlockValidator $validator,
+        private readonly BlockRenderer $renderer,
+    ) {}
+
+    public function index(Request $request): Response
+    {
+        $query = Post::query()->with('author');
+
+        if ($request->user()->role === Role::Staff) {
+            $query->where('author_id', $request->user()->id);
+        }
+
+        $posts = $query->latest('updated_at')->get()->map(fn (Post $post) => [
+            'id' => $post->id,
+            'title' => $post->title,
+            'slug' => $post->slug,
+            'status' => $post->status->value,
+            'channel' => $post->channel->value,
+            'updated_at' => $post->updated_at?->toIso8601String(),
+            'author' => $post->author->name,
+        ]);
+
+        return Inertia::render('Staff/Posts/Index', ['posts' => $posts]);
+    }
+
+    public function create(): Response
+    {
+        return Inertia::render('Staff/Posts/Edit', [
+            'post' => null,
+            'channels' => $this->channelOptions(),
+        ]);
+    }
+
+    public function store(StorePostRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+        $content = $this->validator->validate($validated['content']);
+
+        $post = Post::create([
+            ...$validated,
+            'content' => $content,
+            'slug' => $validated['slug'] ?? Str::slug($validated['title']),
+            'author_id' => $request->user()->id,
+            'status' => PostStatus::Draft,
+        ]);
+
+        $this->saveRevision($post, $request->user()->id);
+
+        return redirect()->route('staff.posts.edit', $post);
+    }
+
+    public function edit(Post $post): Response
+    {
+        $this->authorizeEdit($post);
+
+        return Inertia::render('Staff/Posts/Edit', [
+            'post' => [
+                'id' => $post->id,
+                'title' => $post->title,
+                'slug' => $post->slug,
+                'excerpt' => $post->excerpt,
+                'content' => $post->content,
+                'status' => $post->status->value,
+                'channel' => $post->channel->value,
+                'meta_title' => $post->meta_title,
+                'meta_description' => $post->meta_description,
+                'scheduled_for' => $post->scheduled_for?->format('Y-m-d\TH:i'),
+            ],
+            'channels' => $this->channelOptions(),
+        ]);
+    }
+
+    public function update(UpdatePostRequest $request, Post $post): RedirectResponse
+    {
+        $this->authorizeEdit($post);
+
+        $validated = $request->validated();
+        $content = $this->validator->validate($validated['content']);
+
+        $post->update([
+            ...$validated,
+            'content' => $content,
+        ]);
+
+        $this->saveRevision($post, $request->user()->id);
+
+        return back();
+    }
+
+    public function submitForReview(Request $request, Post $post): RedirectResponse
+    {
+        $this->authorizeEdit($post);
+
+        $post->update(['status' => PostStatus::InReview]);
+
+        return back();
+    }
+
+    public function schedule(Request $request, Post $post): RedirectResponse
+    {
+        $this->authorizeAdmin();
+
+        $request->validate(['scheduled_for' => ['required', 'date', 'after:now']]);
+
+        $post->update([
+            'status' => PostStatus::Scheduled,
+            'scheduled_for' => $request->input('scheduled_for'),
+        ]);
+
+        return back();
+    }
+
+    public function publish(Request $request, Post $post): RedirectResponse
+    {
+        $this->authorizeAdmin();
+
+        if ($post->status === PostStatus::Published) {
+            return back();
+        }
+
+        $post->update([
+            'status' => PostStatus::Published,
+            'published_at' => now(),
+            'scheduled_for' => null,
+        ]);
+
+        return back();
+    }
+
+    public function preview(Request $request, Post $post): Response
+    {
+        $this->authorizeEdit($post);
+
+        return Inertia::render('Articles/Show', [
+            'article' => $this->articlePayload($post),
+            'preview' => true,
+        ]);
+    }
+
+    private function authorizeEdit(Post $post): void
+    {
+        if (! $post->isEditableBy(request()->user())) {
+            abort(403);
+        }
+    }
+
+    private function authorizeAdmin(): void
+    {
+        if (! request()->user()->role->atLeast(Role::Admin)) {
+            abort(403);
+        }
+    }
+
+    private function saveRevision(Post $post, int $editorId): void
+    {
+        PostRevision::create([
+            'post_id' => $post->id,
+            'editor_id' => $editorId,
+            'content' => $post->content,
+            'title' => $post->title,
+        ]);
+    }
+
+    /**
+     * @return array<int, array{value: string, label: string}>
+     */
+    private function channelOptions(): array
+    {
+        return collect(Channel::cases())->map(fn (Channel $c) => [
+            'value' => $c->value,
+            'label' => $c->label(),
+        ])->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function articlePayload(Post $post): array
+    {
+        return [
+            'title' => $post->title,
+            'slug' => $post->slug,
+            'excerpt' => $post->excerpt,
+            'html' => $this->renderer->toHtml($post->content),
+            'channel' => $post->channel->label(),
+            'author' => $post->author->name,
+            'published_at' => $post->published_at?->toIso8601String(),
+            'meta_title' => $post->meta_title ?? $post->title,
+            'meta_description' => $post->meta_description ?? $post->excerpt,
+        ];
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -35,6 +35,9 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'appName' => config('app.name'),
+            'auth' => [
+                'user' => $request->user()?->only(['id', 'name', 'email', 'role']),
+            ],
         ];
     }
 }

--- a/app/Http/Requests/Staff/StorePostRequest.php
+++ b/app/Http/Requests/Staff/StorePostRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Staff;
+
+use App\Enums\Channel;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->role->atLeast(\App\Enums\Role::Staff) ?? false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', 'unique:posts,slug'],
+            'excerpt' => ['nullable', 'string', 'max:1000'],
+            'content' => ['required', 'array'],
+            'channel' => ['required', Rule::enum(Channel::class)],
+            'meta_title' => ['nullable', 'string', 'max:255'],
+            'meta_description' => ['nullable', 'string', 'max:500'],
+        ];
+    }
+}

--- a/app/Http/Requests/Staff/UpdatePostRequest.php
+++ b/app/Http/Requests/Staff/UpdatePostRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Staff;
+
+use App\Enums\Channel;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdatePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->role->atLeast(\App\Enums\Role::Staff) ?? false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['required', 'string', 'max:255', Rule::unique('posts', 'slug')->ignore($this->route('post'))],
+            'excerpt' => ['nullable', 'string', 'max:1000'],
+            'content' => ['required', 'array'],
+            'channel' => ['required', Rule::enum(Channel::class)],
+            'meta_title' => ['nullable', 'string', 'max:255'],
+            'meta_description' => ['nullable', 'string', 'max:500'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateAccountRequest.php
+++ b/app/Http/Requests/UpdateAccountRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateAccountRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => [
+                'required',
+                'string',
+                'lowercase',
+                'email',
+                'max:255',
+                Rule::unique('users')->ignore($this->user()?->id),
+            ],
+        ];
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\Channel;
+use App\Enums\PostStatus;
+use App\Enums\Role;
+use Database\Factories\PostFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+#[Fillable([
+    'author_id', 'title', 'slug', 'excerpt', 'content', 'status', 'channel',
+    'hero_image', 'hero_image_alt', 'hero_image_caption', 'hero_image_credit',
+    'meta_title', 'meta_description', 'canonical_url', 'published_at',
+    'scheduled_for', 'email_on_publish', 'mailing_lists', 'review_notes',
+])]
+class Post extends Model
+{
+    /** @use HasFactory<PostFactory> */
+    use HasFactory, SoftDeletes;
+
+    protected function casts(): array
+    {
+        return [
+            'content' => 'array',
+            'status' => PostStatus::class,
+            'channel' => Channel::class,
+            'published_at' => 'datetime',
+            'scheduled_for' => 'datetime',
+            'email_on_publish' => 'boolean',
+            'mailing_lists' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'author_id');
+    }
+
+    /**
+     * @return HasMany<PostRevision, $this>
+     */
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(PostRevision::class);
+    }
+
+    /**
+     * @return BelongsToMany<Tag, $this>
+     */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class);
+    }
+
+    /**
+     * @param  Builder<Post>  $query
+     * @return Builder<Post>
+     */
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query->where('status', PostStatus::Published)
+            ->whereNotNull('published_at')
+            ->where('published_at', '<=', now());
+    }
+
+    public function isEditableBy(User $user): bool
+    {
+        if ($user->role->atLeast(Role::Admin)) {
+            return true;
+        }
+
+        return $this->author_id === $user->id && $user->role->atLeast(Role::Staff);
+    }
+}

--- a/app/Models/PostRevision.php
+++ b/app/Models/PostRevision.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PostRevision extends Model
+{
+    protected $fillable = ['post_id', 'editor_id', 'content', 'title'];
+
+    protected function casts(): array
+    {
+        return [
+            'content' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Post, $this>
+     */
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function editor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'editor_id');
+    }
+}

--- a/app/Models/Redirect.php
+++ b/app/Models/Redirect.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Redirect extends Model
+{
+    protected $fillable = ['from_path', 'to_path', 'status_code'];
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Tag extends Model
+{
+    protected $fillable = ['name', 'slug'];
+
+    /**
+     * @return BelongsToMany<Post, $this>
+     */
+    public function posts(): BelongsToMany
+    {
+        return $this->belongsToMany(Post::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Enums\Role;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -14,7 +14,7 @@ use Illuminate\Notifications\Notifiable;
 
 #[Fillable(['name', 'email', 'password', 'auth_provider', 'external_id'])]
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
@@ -40,5 +40,17 @@ class User extends Authenticatable
     public function magicLinkTokens(): HasMany
     {
         return $this->hasMany(MagicLinkToken::class);
+    }
+
+    /**
+     * Staff accounts authenticated via Cloudron OIDC are directory-verified.
+     */
+    public function hasVerifiedEmail(): bool
+    {
+        if ($this->auth_provider === 'cloudron_oidc') {
+            return true;
+        }
+
+        return ! is_null($this->email_verified_at);
     }
 }

--- a/app/Services/Auth/StaffReconciler.php
+++ b/app/Services/Auth/StaffReconciler.php
@@ -43,6 +43,7 @@ class StaffReconciler
         $user->forceFill([
             'name' => $identity->name,
             'email' => $identity->email,
+            'email_verified_at' => now(),
             'password' => null,
             'auth_provider' => 'cloudron_oidc',
             'role' => $role,

--- a/app/Services/EditorJs/BlockRenderer.php
+++ b/app/Services/EditorJs/BlockRenderer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services\EditorJs;
+
+/**
+ * Renders validated Editor.js blocks to safe HTML for public display.
+ */
+class BlockRenderer
+{
+    /**
+     * @param  array<string, mixed>  $document
+     */
+    public function toHtml(array $document): string
+    {
+        $html = '';
+
+        foreach ($document['blocks'] ?? [] as $block) {
+            $html .= $this->renderBlock($block);
+        }
+
+        return $html;
+    }
+
+    /**
+     * @param  array<string, mixed>  $block
+     */
+    private function renderBlock(array $block): string
+    {
+        $type = $block['type'] ?? '';
+        $data = $block['data'] ?? [];
+
+        return match ($type) {
+            'paragraph' => '<p>'.e($data['text'] ?? '').'</p>',
+            'header' => '<h'.(int) ($data['level'] ?? 2).'>'.e($data['text'] ?? '').'</h'.(int) ($data['level'] ?? 2).'>',
+            'list' => $this->renderList($data),
+            'quote' => '<blockquote><p>'.e($data['text'] ?? '').'</p>'.(($data['caption'] ?? '') ? '<cite>'.e($data['caption']).'</cite>' : '').'</blockquote>',
+            'image' => $this->renderImage($data),
+            'delimiter' => '<hr />',
+            'callout' => '<aside class="callout">'.e($data['text'] ?? '').'</aside>',
+            'linkTool' => '<p><a href="'.e($data['link'] ?? '').'">'.e($data['meta']['title'] ?? $data['link'] ?? '').'</a></p>',
+            default => '',
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function renderList(array $data): string
+    {
+        $tag = ($data['style'] ?? '') === 'ordered' ? 'ol' : 'ul';
+        $items = '';
+
+        foreach ($data['items'] ?? [] as $item) {
+            $items .= '<li>'.e($item).'</li>';
+        }
+
+        return "<{$tag}>{$items}</{$tag}>";
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function renderImage(array $data): string
+    {
+        $url = e($data['file']['url'] ?? $data['url'] ?? '');
+        $alt = e($data['alt'] ?? '');
+        $caption = ($data['caption'] ?? '') ? '<figcaption>'.e($data['caption']).'</figcaption>' : '';
+
+        return "<figure><img src=\"{$url}\" alt=\"{$alt}\" loading=\"lazy\" />{$caption}</figure>";
+    }
+}

--- a/app/Services/EditorJs/BlockValidator.php
+++ b/app/Services/EditorJs/BlockValidator.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace App\Services\EditorJs;
+
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Server-side Editor.js block allowlist and validation (issue #5).
+ *
+ * Client sanitization is convenience only — every save and render path
+ * must pass through this validator.
+ */
+class BlockValidator
+{
+    /** @var array<int, string> */
+    private const ALLOWED_TYPES = [
+        'paragraph',
+        'header',
+        'list',
+        'quote',
+        'image',
+        'table',
+        'delimiter',
+        'callout',
+        'linkTool',
+        'embed',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $document
+     * @return array<string, mixed>
+     */
+    public function validate(array $document): array
+    {
+        if (! isset($document['blocks']) || ! is_array($document['blocks'])) {
+            throw ValidationException::withMessages([
+                'content' => 'Editor.js document must contain a blocks array.',
+            ]);
+        }
+
+        $blocks = [];
+
+        foreach ($document['blocks'] as $index => $block) {
+            $blocks[] = $this->validateBlock($block, $index);
+        }
+
+        return [
+            'time' => $document['time'] ?? now()->getTimestampMs(),
+            'blocks' => $blocks,
+            'version' => $document['version'] ?? '2.29.0',
+        ];
+    }
+
+    /**
+     * @param  mixed  $block
+     * @return array<string, mixed>
+     */
+    private function validateBlock(mixed $block, int $index): array
+    {
+        if (! is_array($block) || ! isset($block['type'], $block['data'])) {
+            throw ValidationException::withMessages([
+                'content' => "Block at index {$index} is malformed.",
+            ]);
+        }
+
+        $type = (string) $block['type'];
+
+        if (! in_array($type, self::ALLOWED_TYPES, true)) {
+            throw ValidationException::withMessages([
+                'content' => "Block type '{$type}' is not allowed.",
+            ]);
+        }
+
+        $data = $block['data'];
+
+        if (! is_array($data)) {
+            throw ValidationException::withMessages([
+                'content' => "Block data at index {$index} must be an object.",
+            ]);
+        }
+
+        return match ($type) {
+            'paragraph' => ['type' => $type, 'data' => $this->validateParagraph($data, $index)],
+            'header' => ['type' => $type, 'data' => $this->validateHeader($data, $index)],
+            'list' => ['type' => $type, 'data' => $this->validateList($data, $index)],
+            'quote' => ['type' => $type, 'data' => $this->validateQuote($data, $index)],
+            'image' => ['type' => $type, 'data' => $this->validateImage($data, $index)],
+            'delimiter' => ['type' => $type, 'data' => new \stdClass],
+            'callout' => ['type' => $type, 'data' => $this->validateCallout($data, $index)],
+            'linkTool' => ['type' => $type, 'data' => $this->validateLink($data, $index)],
+            default => ['type' => $type, 'data' => $data],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, string>
+     */
+    private function validateParagraph(array $data, int $index): array
+    {
+        $text = $this->sanitizeText($data['text'] ?? '', $index, 'paragraph');
+
+        return ['text' => $text];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function validateHeader(array $data, int $index): array
+    {
+        $level = (int) ($data['level'] ?? 2);
+
+        if (! in_array($level, [2, 3, 4], true)) {
+            throw ValidationException::withMessages([
+                'content' => "Header at index {$index} must be level 2, 3, or 4.",
+            ]);
+        }
+
+        return [
+            'text' => $this->sanitizeText($data['text'] ?? '', $index, 'header'),
+            'level' => $level,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function validateList(array $data, int $index): array
+    {
+        $style = ($data['style'] ?? 'unordered') === 'ordered' ? 'ordered' : 'unordered';
+        $items = $data['items'] ?? [];
+
+        if (! is_array($items)) {
+            throw ValidationException::withMessages([
+                'content' => "List at index {$index} must have items array.",
+            ]);
+        }
+
+        return [
+            'style' => $style,
+            'items' => array_map(
+                fn ($item) => $this->sanitizeText((string) $item, $index, 'list item'),
+                $items
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, string>
+     */
+    private function validateQuote(array $data, int $index): array
+    {
+        return [
+            'text' => $this->sanitizeText($data['text'] ?? '', $index, 'quote'),
+            'caption' => $this->sanitizeText($data['caption'] ?? '', $index, 'quote caption'),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, string>
+     */
+    private function validateImage(array $data, int $index): array
+    {
+        $url = (string) ($data['file']['url'] ?? $data['url'] ?? '');
+
+        if ($url === '' || ! filter_var($url, FILTER_VALIDATE_URL)) {
+            throw ValidationException::withMessages([
+                'content' => "Image at index {$index} requires a valid URL.",
+            ]);
+        }
+
+        $alt = $this->sanitizeText($data['alt'] ?? '', $index, 'image alt');
+
+        if ($alt === '') {
+            throw ValidationException::withMessages([
+                'content' => "Image at index {$index} requires alt text.",
+            ]);
+        }
+
+        return [
+            'file' => ['url' => $url],
+            'alt' => $alt,
+            'caption' => $this->sanitizeText($data['caption'] ?? '', $index, 'caption'),
+            'credit' => $this->sanitizeText($data['credit'] ?? '', $index, 'credit'),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, string>
+     */
+    private function validateCallout(array $data, int $index): array
+    {
+        return [
+            'text' => $this->sanitizeText($data['text'] ?? '', $index, 'callout'),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, string>
+     */
+    private function validateLink(array $data, int $index): array
+    {
+        $url = (string) ($data['link'] ?? '');
+
+        if ($url === '' || ! filter_var($url, FILTER_VALIDATE_URL)) {
+            throw ValidationException::withMessages([
+                'content' => "Link at index {$index} requires a valid URL.",
+            ]);
+        }
+
+        return [
+            'link' => $url,
+            'meta' => [
+                'title' => $this->sanitizeText($data['meta']['title'] ?? '', $index, 'link title'),
+            ],
+        ];
+    }
+
+    private function sanitizeText(string $text, int $index, string $context): string
+    {
+        if (strlen($text) > 10000) {
+            throw ValidationException::withMessages([
+                'content' => "Text in {$context} at index {$index} exceeds maximum length.",
+            ]);
+        }
+
+        if (preg_match('/<script|javascript:/i', $text)) {
+            throw ValidationException::withMessages([
+                'content' => "Disallowed content in {$context} at index {$index}.",
+            ]);
+        }
+
+        return strip_tags($text);
+    }
+}

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\Channel;
+use App\Enums\PostStatus;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Post>
+ */
+class PostFactory extends Factory
+{
+    protected $model = Post::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $title = fake()->sentence();
+
+        return [
+            'author_id' => User::factory(),
+            'title' => $title,
+            'slug' => Str::slug($title).'-'.fake()->unique()->numberBetween(1, 9999),
+            'excerpt' => fake()->paragraph(),
+            'content' => [
+                'time' => now()->getTimestampMs(),
+                'blocks' => [
+                    ['type' => 'paragraph', 'data' => ['text' => fake()->paragraph()]],
+                ],
+                'version' => '2.29.0',
+            ],
+            'status' => PostStatus::Draft,
+            'channel' => Channel::ApesCic,
+        ];
+    }
+
+    public function published(): static
+    {
+        return $this->state(fn () => [
+            'status' => PostStatus::Published,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+}

--- a/database/migrations/2026_08_06_100000_create_posts_table.php
+++ b/database/migrations/2026_08_06_100000_create_posts_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('author_id')->constrained('users')->cascadeOnDelete();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->text('excerpt')->nullable();
+            $table->json('content');
+            $table->string('status')->default('draft')->index();
+            $table->string('channel')->index();
+            $table->string('hero_image')->nullable();
+            $table->string('hero_image_alt')->nullable();
+            $table->string('hero_image_caption')->nullable();
+            $table->string('hero_image_credit')->nullable();
+            $table->string('meta_title')->nullable();
+            $table->string('meta_description', 500)->nullable();
+            $table->string('canonical_url')->nullable();
+            $table->timestamp('published_at')->nullable()->index();
+            $table->timestamp('scheduled_for')->nullable()->index();
+            $table->boolean('email_on_publish')->default(false);
+            $table->json('mailing_lists')->nullable();
+            $table->text('review_notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/database/migrations/2026_08_06_100001_create_post_revisions_table.php
+++ b/database/migrations/2026_08_06_100001_create_post_revisions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('post_revisions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('editor_id')->constrained('users')->cascadeOnDelete();
+            $table->json('content');
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('post_revisions');
+    }
+};

--- a/database/migrations/2026_08_06_100002_create_tags_table.php
+++ b/database/migrations/2026_08_06_100002_create_tags_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+            $table->primary(['post_id', 'tag_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('post_tag');
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2026_08_06_100003_create_redirects_table.php
+++ b/database/migrations/2026_08_06_100003_create_redirects_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('redirects', function (Blueprint $table) {
+            $table->id();
+            $table->string('from_path')->unique();
+            $table->string('to_path');
+            $table->unsignedSmallInteger('status_code')->default(301);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('redirects');
+    }
+};

--- a/docs/deployment-beta-acceptance.md
+++ b/docs/deployment-beta-acceptance.md
@@ -1,0 +1,61 @@
+# Beta deployment acceptance checklist (issue #3, #11)
+
+Use this checklist during the first watched beta deploy to `beta.apesnews.org.uk`.
+Record evidence (screenshots, command output, timestamps) in issue #3 comments.
+
+## Pre-deploy
+
+- [ ] GitHub `beta` environment secrets configured (`CLOUDRON_FQDN`, `CLOUDRON_TOKEN`, `CLOUDRON_APP_ID`, `CLOUDRON_APP_ORIGIN_HOST`)
+- [ ] One-time server setup complete (PHP 8.4, Apache config, `run.sh`, scheduler cron)
+- [ ] Redis addon enabled and `CLOUDRON_REDIS_*` vars present
+- [ ] OIDC client registered with beta redirect URI
+- [ ] LDAP groups created and `config/rbac.php` keys verified
+- [ ] `php artisan deploy:preflight --target=beta` passes on a clean checkout with `APP_DEBUG=false` and Cloudron database reachable
+
+## Deploy execution
+
+- [ ] Trigger "Deploy to Cloudron (beta)" workflow manually from `main`
+- [ ] Cloudron backup created successfully before activation
+- [ ] Migrations run without error
+- [ ] Health check passes within 60 seconds
+- [ ] Workflow reports success
+
+## Post-deploy verification
+
+| Check | Command / action | Expected | Evidence |
+|-------|------------------|----------|----------|
+| Health | `curl https://beta.apesnews.org.uk/health` | `database: true`, `cache: true` | |
+| Homepage | Visit `/` | Renders without error | |
+| Login | Visit `/login` | Staff sign-in visible when OIDC configured | |
+| Staff OIDC | Complete staff login | User created with correct role | |
+| Queue worker | Dispatch test job | Job processed via Redis | |
+| Scheduler | Wait for scheduled command | `staff:reconcile-roles` runs daily | |
+| Logs | Check `/app/data/shared/storage/logs/` | No secrets in output | |
+
+## Rollback drill
+
+- [ ] Note current release SHA from `/app/data/current`
+- [ ] Run `deploy/cloudron-rollback.sh` via `cloudron exec`
+- [ ] Restart app
+- [ ] Verify previous release serves `/health` successfully
+- [ ] Re-deploy latest release to restore beta to current state
+- [ ] Confirm rollback did not delete release directories
+
+## Local preflight evidence (2026-08-06)
+
+Run from development checkout before Cloudron credentials are available:
+
+```
+php artisan deploy:preflight --target=beta
+```
+
+Expected local failures (no Cloudron env):
+- `git.clean_tree` — uncommitted changes during active development
+- `env.debug_disabled` — `APP_DEBUG=true` in local `.env`
+- `database.reachable` — no Cloudron MySQL from local machine
+
+These are expected in local dev. Re-run preflight from CI or a machine with beta `.env` before deploying.
+
+## Authorization
+
+Completing this checklist does **not** authorize production cutover (#11) or Ghost retirement.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,13 +5,15 @@ app (`74a2a784-a161-4787-84ff-2b8efc957bc8`), which currently runs Ghost
 and will be repointed at this app per the epic (#1) plan: build and accept
 at `beta.apesnews.org.uk`, then cut over `apesnews.org.uk` separately (#11).
 
-**Nothing in this document has been run.** The workflow, scripts, and
-setup steps below are written and internally consistent against
-Cloudron's documented behaviour (docs.cloudron.io), but there is no
-Cloudron API token or access from this environment to test them end to
-end. Treat the first real run as the acceptance exercise issue #3 and
-#11 both call for - run it against beta, watched, with `docs.cloudron.io`
-open, before trusting it unattended.
+**Local preflight has been run** (2026-08-06); a watched beta deploy against
+Cloudron has not yet been executed from this environment. See
+[`docs/deployment-beta-acceptance.md`](deployment-beta-acceptance.md) for
+the full acceptance checklist. The workflow, scripts, and setup steps below
+are written and internally consistent against Cloudron's documented
+behaviour (docs.cloudron.io), but there is no Cloudron API token or access
+from this environment to test them end to end. Treat the first real run as
+the acceptance exercise issue #3 and #11 both call for — run it against
+beta, watched, with `docs.cloudron.io` open, before trusting it unattended.
 
 ## How a release is structured on the server
 
@@ -137,6 +139,10 @@ runs identically from PowerShell, cmd, or bash - no separate Windows
 script to maintain. Run it locally against a non-production database
 before trusting a new environment, and it's what
 `DeployPreflightCommandTest` exercises in CI.
+
+**Local run (2026-08-06):** preflight executed from dev checkout. Expected
+failures without Cloudron credentials: uncommitted changes, `APP_DEBUG=true`,
+database unreachable. See [`deployment-beta-acceptance.md`](deployment-beta-acceptance.md).
 
 ## What this does not do
 

--- a/docs/design/accessibility-notes.md
+++ b/docs/design/accessibility-notes.md
@@ -1,0 +1,72 @@
+# APES Newsroom — Accessibility Notes (draft)
+
+> **Status:** First-pass draft targeting WCAG 2.2 AA (#2, #10).
+
+## Global requirements
+
+- [ ] Skip link to `#main-content` on every page
+- [ ] Logical heading hierarchy (one `h1` per page)
+- [ ] Landmarks: `header`, `nav`, `main`, `footer`
+- [ ] Visible focus on all interactive elements
+- [ ] 4.5:1 contrast for body text, 3:1 for large text
+- [ ] No information conveyed by colour alone
+- [ ] 200% zoom without horizontal scroll (reflow)
+- [ ] 44×44px minimum touch targets
+- [ ] Respect `prefers-reduced-motion`
+
+## Public newsroom
+
+| Surface | Checks |
+|---------|--------|
+| Homepage | Keyboard nav through featured cards; alt text on hero images |
+| Channel pages | Channel accent does not reduce text contrast below AA |
+| Article | Semantic article markup; image alt/caption/credit; readable line length |
+| Search | Labelled input; results announced; empty state |
+| RSS/sitemap | Machine-readable; no a11y impact on humans |
+
+## Authentication
+
+| Surface | Checks |
+|---------|--------|
+| Login/register | Labels associated with inputs; errors linked via `aria-describedby` |
+| Magic link | Clear instructions; no account enumeration via UI |
+| Staff OIDC | Accessible button; error messages readable |
+| Email verification | Status messages announced |
+
+## Editor.js workspace
+
+| Surface | Checks |
+|---------|--------|
+| Block toolbar | Keyboard-operable; focus not trapped |
+| Image blocks | Alt text required before save |
+| Preview | Same renderer as production; `noindex` |
+
+## Mailing preferences
+
+| Surface | Checks |
+|---------|--------|
+| Signup | Unchecked list boxes; clear purpose labels |
+| Preference centre | Per-list controls labelled; unsubscribe-all available |
+| HTML email | Semantic structure; alt on hero; sufficient contrast |
+
+## Moderation
+
+| Surface | Checks |
+|---------|--------|
+| Queues | Table/list keyboard navigable; action buttons labelled |
+| Rejection reasons | Visible to moderators only; not leaked publicly |
+
+## Testing plan
+
+1. Automated: axe-core in CI on key page templates
+2. Manual keyboard: tab through all interactive flows
+3. Screen reader: NVDA/VoiceOver smoke on login, article read, preference centre
+4. Zoom: 200% on article and form pages
+
+## Sign-off
+
+- [ ] Design review complete
+- [ ] Automated checks green
+- [ ] Manual keyboard pass
+- [ ] Screen reader smoke pass
+- [ ] Named accessibility approver recorded

--- a/docs/design/component-inventory.md
+++ b/docs/design/component-inventory.md
@@ -1,0 +1,70 @@
+# APES Newsroom — Component Inventory (draft)
+
+> **Status:** First-pass draft for stakeholder review (#2).
+
+## Layout
+
+| Component | Description | States |
+|-----------|-------------|--------|
+| `SiteHeader` | Logo, primary nav, search, account | default, mobile menu open |
+| `SiteFooter` | Links, charity info, privacy | default |
+| `SkipLink` | Skip to main content | focus visible |
+| `PageContainer` | Max-width wrapper with gutters | — |
+| `ChannelHero` | Channel landing hero with accent | default |
+
+## Content
+
+| Component | Description | States |
+|-----------|-------------|--------|
+| `ArticleCard` | Image, title, excerpt, meta | default, featured |
+| `ArticleList` | Grid/list of cards | loading, empty |
+| `ArticleBody` | Rendered Editor.js blocks | — |
+| `AuthorByline` | Name, date, channel | linked author |
+| `TagPill` | Category/tag label | default, active |
+| `Pagination` | Page navigation | disabled prev/next |
+
+## Forms & auth
+
+| Component | Description | States |
+|-----------|-------------|--------|
+| `TextInput` | Labelled input with error | default, error, disabled |
+| `Button` | Primary/secondary/destructive | default, loading, disabled |
+| `FormError` | Inline validation message | — |
+| `AuthCard` | Centred auth form layout | — |
+
+## Editorial (staff)
+
+| Component | Description | States |
+|-----------|-------------|--------|
+| `EditorWorkspace` | Editor.js shell + sidebar | saving, conflict, read-only |
+| `PostStatusBadge` | draft/in_review/scheduled/published | per status |
+| `ReviewPanel` | Approve/reject with notes | admin only |
+| `SeoFields` | Meta title, description, canonical | — |
+| `SchedulePicker` | Europe/London datetime | GMT/BST aware |
+
+## Engagement
+
+| Component | Description | States |
+|-----------|-------------|--------|
+| `ReactionBar` | Helpful/Support/Thank You toggles | default, toggled, disabled |
+| `CommentForm` | Plain text comment input | pending moderation notice |
+| `CommentList` | Approved comments only | empty, loading |
+| `ProfileCard` | Display name, avatar, bio | private, pending, approved |
+
+## Email
+
+| Component | Description | States |
+|-----------|-------------|--------|
+| `CampaignEmail` | Post-summary template | preview, test send |
+
+## Feedback
+
+| Component | Description | States |
+|-----------|-------------|--------|
+| `EmptyState` | No content message + CTA | per context |
+| `ErrorPage` | Branded 404/410/429/500 | per status |
+| `Toast` | Transient success/error | — |
+
+## Tailwind mapping
+
+Tokens from `tokens.md` map to Tailwind theme extensions in `resources/css/app.css`. Components use semantic class names rather than raw hex values.

--- a/docs/design/email-templates.md
+++ b/docs/design/email-templates.md
@@ -1,0 +1,60 @@
+# APES Newsroom — Email Template Spec (draft)
+
+> **Status:** First-pass draft for stakeholder review (#2, #7).
+
+## Campaign type: post-summary
+
+Sent when an admin approves a published post with "email this post" enabled. One individually addressed message per recipient.
+
+## Layout (single column, max 600px)
+
+```
+┌─────────────────────────────────────┐
+│  APES Newsroom logo                 │
+│  [Channel name pill]                │
+├─────────────────────────────────────┤
+│  [Hero image — alt text required]   │
+│                                     │
+│  Article title (linked)             │
+│  Author · Date · Channel            │
+│                                     │
+│  Excerpt paragraph (plain text)     │
+│                                     │
+│  [ Read the full story → ]          │
+├─────────────────────────────────────┤
+│  APES CIC charity details           │
+│  Contact address                    │
+│  Manage preferences | Unsubscribe │
+└─────────────────────────────────────┘
+```
+
+## Content rules
+
+- **Include:** branded title, hero image, excerpt, author/date/channel metadata, read-more link
+- **Exclude:** full Editor.js document, tracking pixels, click tracking, CC/BCC
+- **Snapshot:** campaign content frozen at approval; later article edits do not change in-flight sends
+
+## Headers
+
+- `From`: configured Cloudron SMTP identity
+- `Reply-To`: editorial contact address
+- `List-Unsubscribe`: signed one-click URL per list
+- `List-Unsubscribe-Post`: `List-Unsubscribe=One-Click` (RFC 8058)
+
+## Accessibility (HTML email)
+
+- Semantic headings (`h1` for title)
+- Alt text on hero image (required)
+- Sufficient colour contrast (4.5:1 body text)
+- Plain-text alternative part generated alongside HTML
+- Links descriptive ("Read the full story" not "click here")
+
+## Test send
+
+- Clearly labelled "Test send" in admin UI
+- Test sends use a dedicated queue/job type that cannot trigger live campaign delivery
+- Test recipient must be explicitly entered; never pre-filled from live lists
+
+## Throttle
+
+Default 60 recipients/minute, configurable after capacity testing on beta.

--- a/docs/design/sitemap.md
+++ b/docs/design/sitemap.md
@@ -1,0 +1,85 @@
+# APES Newsroom — Sitemap (draft)
+
+> **Status:** First-pass draft for stakeholder review (#2). Not approved for implementation sign-off.
+
+## Public surfaces
+
+| Path | Page | Notes |
+|------|------|-------|
+| `/` | Homepage | Featured + recent stories across all channels |
+| `/apes-cic` | APES CIC channel | Mission-led landing, channel stories |
+| `/apes-shelter-rescue` | Shelter & Rescue channel | Distinct accent, same layout system |
+| `/apes-pet-care-clinic` | Pet Care Clinic channel | Distinct accent, same layout system |
+| `/articles/{slug}` | Article | Long-form reading, SEO, comments/reactions counts |
+| `/authors/{slug}` | Author | Staff/public author profiles where approved |
+| `/search` | Search | Full-text across published content |
+| `/category/{slug}` | Category archive | Filtered article list |
+| `/tag/{slug}` | Tag archive | Filtered article list |
+| `/archive/{year}` | Date archive | Year listing |
+| `/archive/{year}/{month}` | Month archive | Month listing |
+| `/rss.xml` | RSS feed | All channels or per-channel variants |
+| `/sitemap.xml` | XML sitemap | Published content + news entries |
+| `/login` | Login | Password, magic link, staff OIDC entry |
+| `/register` | Register | Public account creation |
+| `/mailing/preferences` | Preference centre | Signed links for non-account contacts |
+| `/mailing/unsubscribe` | Unsubscribe | Per-list and unsubscribe-all |
+
+## Authenticated surfaces (public accounts)
+
+| Path | Page | Auth |
+|------|------|------|
+| `/account` | Profile & settings | Verified public account |
+| `/account/export` | Data export | Verified public account |
+| `/verify-email` | Email verification | Authenticated, unverified |
+
+## Staff workspace
+
+| Path | Page | Role |
+|------|------|------|
+| `/staff` | Staff dashboard | staff+ |
+| `/staff/posts` | Draft list | staff+ (own drafts) |
+| `/staff/posts/new` | New draft | staff+ |
+| `/staff/posts/{id}/edit` | Editor.js workspace | staff+ (own) / admin+ (all) |
+| `/staff/posts/{id}/preview` | Preview (noindex) | staff+ with access |
+
+## Admin workspace
+
+| Path | Page | Role |
+|------|------|------|
+| `/admin/review` | Review queue | admin+ |
+| `/admin/campaigns` | Campaign management | admin+ |
+| `/admin/moderation/profiles` | Profile moderation | admin+ |
+| `/admin/moderation/comments` | Comment moderation | admin+ |
+
+## Super admin
+
+| Path | Page | Role |
+|------|------|------|
+| `/super-admin/settings` | Newsroom configuration | super_admin |
+| `/super-admin/audit` | Audit log access | super_admin |
+
+## Error pages
+
+| Status | Page |
+|--------|------|
+| 404 | Not found — branded, helpful navigation |
+| 410 | Gone — retired content |
+| 429 | Rate limited |
+| 500 | Server error — calm, no technical detail |
+
+## Navigation hierarchy
+
+```
+Home
+├── APES CIC
+├── Shelter & Rescue
+├── Pet Care Clinic
+├── Search
+├── About APES (static, optional v1)
+└── Account / Login
+    ├── Profile
+    ├── Mailing preferences
+    └── Staff sign-in (when OIDC configured)
+```
+
+Staff users see an additional **Workspace** entry in the header after authentication.

--- a/docs/design/tokens.md
+++ b/docs/design/tokens.md
@@ -1,0 +1,64 @@
+# APES Newsroom — Design Tokens (draft)
+
+> **Status:** First-pass draft for stakeholder review (#2).
+
+## Brand direction
+
+Mission-led editorial: authentic animal-care imagery, warm APES accents, high-contrast long-form reading, calm accessible interfaces. Three channels share a unified system with distinct accent colours.
+
+## Colour
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--color-apes-primary` | `#2D6A4F` | Primary actions, APES CIC accent |
+| `--color-shelter-accent` | `#BC6C25` | Shelter & Rescue channel |
+| `--color-clinic-accent` | `#457B9D` | Pet Care Clinic channel |
+| `--color-neutral-900` | `#1A1A1A` | Headings, body text |
+| `--color-neutral-600` | `#525252` | Secondary text |
+| `--color-neutral-100` | `#F5F5F4` | Page backgrounds |
+| `--color-surface` | `#FFFFFF` | Cards, panels |
+| `--color-error` | `#B91C1C` | Errors, destructive actions |
+| `--color-success` | `#15803D` | Success states |
+| `--color-focus` | `#2563EB` | Focus rings |
+
+## Typography
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--font-sans` | Instrument Sans, system-ui | UI and body |
+| `--font-serif` | Georgia, serif | Article long-form (optional) |
+| `--text-xs` | 0.75rem / 1rem | Captions, metadata |
+| `--text-sm` | 0.875rem / 1.25rem | Secondary UI |
+| `--text-base` | 1rem / 1.5rem | Body |
+| `--text-lg` | 1.125rem / 1.75rem | Lead paragraphs |
+| `--text-xl` | 1.25rem / 1.75rem | Section headings |
+| `--text-2xl` | 1.5rem / 2rem | Page titles |
+| `--text-3xl` | 1.875rem / 2.25rem | Article titles (mobile) |
+| `--text-4xl` | 2.25rem / 2.5rem | Article titles (desktop) |
+
+## Spacing
+
+4px base grid: `--space-1` (4px) through `--space-16` (64px). Article content max-width: `42rem` (prose). Page gutters: `1.5rem` mobile, `2rem` tablet+.
+
+## Focus
+
+- Visible 2px `--color-focus` outline with 2px offset
+- Never remove focus indicators
+- Focus must not be obscured by sticky headers
+
+## Touch targets
+
+Minimum 44×44px for interactive elements (WCAG 2.2 target size).
+
+## Motion
+
+Respect `prefers-reduced-motion`: disable non-essential transitions when set.
+
+## Channel differentiation
+
+Each channel page uses its accent colour for:
+- Hero band background tint
+- Category pill borders
+- Section heading underlines
+
+Shared chrome (header, footer, article body) remains consistent across channels.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -6,4 +6,12 @@
 @theme {
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', 'Noto Color Emoji';
+
+    --color-apes-primary: #2D6A4F;
+    --color-shelter-accent: #BC6C25;
+    --color-clinic-accent: #457B9D;
+    --color-neutral-900: #1A1A1A;
+    --color-neutral-600: #525252;
+    --color-neutral-100: #F5F5F4;
+    --color-focus: #2563EB;
 }

--- a/resources/js/Pages/Account/Profile.tsx
+++ b/resources/js/Pages/Account/Profile.tsx
@@ -1,0 +1,83 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+type ProfileUser = {
+    name: string;
+    email: string;
+    role: string;
+    auth_provider: string | null;
+};
+
+export default function Profile({ user, status }: { user: ProfileUser; status?: string }) {
+    const { data, setData, patch, processing, errors, delete: destroy } = useForm({
+        name: user.name,
+        email: user.email,
+    });
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        patch('/account');
+    };
+
+    const deleteAccount = () => {
+        if (confirm('Delete your account permanently? This cannot be undone.')) {
+            destroy('/account');
+        }
+    };
+
+    return (
+        <>
+            <Head title="Your account" />
+            <main className="mx-auto flex min-h-screen max-w-lg flex-col gap-8 px-6 py-12">
+                <div>
+                    <h1 className="text-2xl font-semibold text-neutral-900">Your account</h1>
+                    <p className="mt-1 text-sm text-neutral-600">Manage your profile and data.</p>
+                </div>
+
+                {status === 'profile-updated' && <p className="text-sm text-green-700">Profile updated.</p>}
+                {status === 'email-verified' && <p className="text-sm text-green-700">Email verified.</p>}
+
+                <form onSubmit={submit} className="flex flex-col gap-4">
+                    <div>
+                        <label htmlFor="name">Name</label>
+                        <input id="name" value={data.name} onChange={(e) => setData('name', e.target.value)} required />
+                        {errors.name && <p className="text-sm text-red-600">{errors.name}</p>}
+                    </div>
+                    <div>
+                        <label htmlFor="email">Email</label>
+                        <input
+                            id="email"
+                            type="email"
+                            value={data.email}
+                            onChange={(e) => setData('email', e.target.value)}
+                            required
+                            disabled={user.auth_provider === 'cloudron_oidc'}
+                        />
+                        {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
+                    </div>
+                    <button type="submit" disabled={processing}>
+                        Save changes
+                    </button>
+                </form>
+
+                <section className="flex flex-col gap-3 border-t border-neutral-200 pt-6">
+                    <h2 className="text-lg font-medium">Your data</h2>
+                    <Link href="/account/export" className="text-sm underline">
+                        Download account data (JSON)
+                    </Link>
+                </section>
+
+                <section className="flex flex-col gap-3 border-t border-neutral-200 pt-6">
+                    <h2 className="text-lg font-medium text-red-800">Danger zone</h2>
+                    <button type="button" onClick={deleteAccount} className="w-fit text-sm text-red-700 underline">
+                        Delete account
+                    </button>
+                </section>
+
+                <p className="text-sm">
+                    <Link href="/">Back to home</Link>
+                </p>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Articles/Show.tsx
+++ b/resources/js/Pages/Articles/Show.tsx
@@ -1,0 +1,59 @@
+import { Head, Link } from '@inertiajs/react';
+
+type Article = {
+    title: string;
+    slug: string;
+    excerpt: string | null;
+    html: string;
+    channel: string;
+    channel_slug: string;
+    author: string;
+    published_at: string | null;
+    meta_title: string;
+    meta_description: string | null;
+    tags?: string[];
+};
+
+export default function ArticleShow({ article, preview }: { article: Article; preview?: boolean }) {
+    return (
+        <>
+            <Head title={article.meta_title}>
+                <meta name="description" content={article.meta_description ?? ''} />
+                {preview && <meta name="robots" content="noindex,nofollow" />}
+                <meta property="og:title" content={article.meta_title} />
+                <meta property="og:description" content={article.meta_description ?? ''} />
+                <meta property="og:type" content="article" />
+                <script type="application/ld+json">
+                    {JSON.stringify({
+                        '@context': 'https://schema.org',
+                        '@type': 'Article',
+                        headline: article.title,
+                        author: { '@type': 'Person', name: article.author },
+                        datePublished: article.published_at,
+                    })}
+                </script>
+            </Head>
+            {preview && (
+                <div className="bg-amber-100 px-4 py-2 text-center text-sm text-amber-900">Preview — not indexed</div>
+            )}
+            <main className="mx-auto max-w-3xl px-6 py-12">
+                <Link href={`/${article.channel_slug}`} className="text-sm text-apes-primary">
+                    {article.channel}
+                </Link>
+                <article>
+                    <h1 className="mt-4 text-4xl font-semibold text-neutral-900">{article.title}</h1>
+                    <p className="mt-2 text-sm text-neutral-600">
+                        By {article.author}
+                        {article.published_at && (
+                            <> · {new Date(article.published_at).toLocaleDateString('en-GB')}</>
+                        )}
+                    </p>
+                    <div
+                        className="prose prose-neutral mt-8 max-w-none"
+                        dangerouslySetInnerHTML={{ __html: article.html }}
+                    />
+                </article>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Auth/VerifyEmail.tsx
+++ b/resources/js/Pages/Auth/VerifyEmail.tsx
@@ -1,0 +1,36 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+export default function VerifyEmail({ status }: { status?: string }) {
+    const { post, processing } = useForm({});
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        post('/email/verification-notification');
+    };
+
+    return (
+        <>
+            <Head title="Verify email" />
+            <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6">
+                <h1 className="text-2xl font-semibold text-neutral-900">Verify your email</h1>
+                <p className="text-sm text-neutral-600">
+                    Thanks for registering. Please check your email for a verification link before using your account.
+                </p>
+                {status === 'verification-link-sent' && (
+                    <p className="text-sm text-green-700">A new verification link has been sent to your email address.</p>
+                )}
+                <form onSubmit={submit}>
+                    <button type="submit" disabled={processing}>
+                        Resend verification email
+                    </button>
+                </form>
+                <p className="text-sm">
+                    <Link href="/logout" method="post" as="button">
+                        Log out
+                    </Link>
+                </p>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Channels/Show.tsx
+++ b/resources/js/Pages/Channels/Show.tsx
@@ -1,0 +1,40 @@
+import { Head, Link } from '@inertiajs/react';
+
+type Post = {
+    title: string;
+    slug: string;
+    excerpt: string | null;
+    author: string;
+    published_at: string | null;
+};
+
+export default function ChannelShow({
+    channel,
+    posts,
+}: {
+    channel: { slug: string; label: string };
+    posts: { data: Post[] };
+}) {
+    return (
+        <>
+            <Head title={channel.label} />
+            <main className="mx-auto max-w-5xl px-6 py-12">
+                <Link href="/" className="text-sm text-neutral-600 hover:underline">
+                    ← Home
+                </Link>
+                <h1 className="mt-4 text-3xl font-semibold text-neutral-900">{channel.label}</h1>
+                <ul className="mt-8 grid gap-6">
+                    {posts.data.map((post) => (
+                        <li key={post.slug} className="border-b border-neutral-200 pb-6">
+                            <h2 className="text-xl font-semibold">
+                                <Link href={`/articles/${post.slug}`}>{post.title}</Link>
+                            </h2>
+                            {post.excerpt && <p className="mt-2 text-neutral-600">{post.excerpt}</p>}
+                            <p className="mt-2 text-sm text-neutral-500">{post.author}</p>
+                        </li>
+                    ))}
+                </ul>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Search/Index.tsx
+++ b/resources/js/Pages/Search/Index.tsx
@@ -1,0 +1,47 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+type Result = { title: string; slug: string; excerpt: string | null; published_at: string | null };
+
+export default function SearchIndex({ query, results }: { query: string; results: Result[] }) {
+    const { data, setData, get } = useForm({ q: query });
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        get('/search', { preserveState: true });
+    };
+
+    return (
+        <>
+            <Head title="Search" />
+            <main className="mx-auto max-w-3xl px-6 py-12">
+                <h1 className="text-2xl font-semibold">Search</h1>
+                <form onSubmit={submit} className="mt-4 flex gap-2">
+                    <label htmlFor="q" className="sr-only">
+                        Search
+                    </label>
+                    <input
+                        id="q"
+                        value={data.q}
+                        onChange={(e) => setData('q', e.target.value)}
+                        className="flex-1 rounded border border-neutral-300 px-3 py-2"
+                        placeholder="Search articles…"
+                    />
+                    <button type="submit" className="rounded bg-apes-primary px-4 py-2 text-white">
+                        Search
+                    </button>
+                </form>
+                <ul className="mt-8 space-y-4">
+                    {results.map((r) => (
+                        <li key={r.slug}>
+                            <Link href={`/articles/${r.slug}`} className="text-lg font-medium hover:underline">
+                                {r.title}
+                            </Link>
+                            {r.excerpt && <p className="text-sm text-neutral-600">{r.excerpt}</p>}
+                        </li>
+                    ))}
+                </ul>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Staff/Posts/Edit.tsx
+++ b/resources/js/Pages/Staff/Posts/Edit.tsx
@@ -1,0 +1,146 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+type Channel = { value: string; label: string };
+
+type PostData = {
+    id: number;
+    title: string;
+    slug: string;
+    excerpt: string | null;
+    content: { blocks: unknown[] };
+    status: string;
+    channel: string;
+    meta_title: string | null;
+    meta_description: string | null;
+    scheduled_for: string | null;
+};
+
+const emptyContent = {
+    time: Date.now(),
+    blocks: [{ type: 'paragraph', data: { text: '' } }],
+    version: '2.29.0',
+};
+
+type PostForm = {
+    title: string;
+    slug: string;
+    excerpt: string;
+    content: { time?: number; blocks: Array<{ type: string; data: { text?: string } }>; version?: string };
+    channel: string;
+    meta_title: string;
+    meta_description: string;
+};
+
+export default function PostEdit({ post, channels }: { post: PostData | null; channels: Channel[] }) {
+    const isNew = post === null;
+
+    const { data, setData, post: submitPost, patch, processing, errors } = useForm<PostForm>({
+        title: post?.title ?? '',
+        slug: post?.slug ?? '',
+        excerpt: post?.excerpt ?? '',
+        content: (post?.content as PostForm['content']) ?? emptyContent,
+        channel: post?.channel ?? channels[0]?.value ?? 'apes_cic',
+        meta_title: post?.meta_title ?? '',
+        meta_description: post?.meta_description ?? '',
+    });
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        if (isNew) {
+            submitPost('/staff/posts');
+        } else {
+            patch(`/staff/posts/${post.id}`);
+        }
+    };
+
+    const updateContentText = (text: string) => {
+        setData('content', {
+            ...data.content,
+            blocks: [{ type: 'paragraph', data: { text } }],
+        });
+    };
+
+    const bodyText = data.content.blocks[0]?.data?.text ?? '';
+
+    return (
+        <>
+            <Head title={isNew ? 'New post' : `Edit: ${post.title}`} />
+            <main className="mx-auto max-w-3xl px-6 py-12">
+                <Link href="/staff/posts" className="text-sm text-neutral-600 hover:underline">
+                    ← Posts
+                </Link>
+                <h1 className="mt-4 text-2xl font-semibold">{isNew ? 'New draft' : 'Edit draft'}</h1>
+                {!isNew && (
+                    <p className="mt-1 text-sm text-neutral-600">
+                        Status: {post.status}{' '}
+                        <Link href={`/staff/posts/${post.id}/preview`} className="underline">
+                            Preview
+                        </Link>
+                    </p>
+                )}
+                <form onSubmit={submit} className="mt-8 flex flex-col gap-4">
+                    <div>
+                        <label htmlFor="title">Title</label>
+                        <input
+                            id="title"
+                            value={data.title}
+                            onChange={(e) => setData('title', e.target.value)}
+                            required
+                            className="w-full rounded border px-3 py-2"
+                        />
+                        {errors.title && <p className="text-sm text-red-600">{errors.title}</p>}
+                    </div>
+                    <div>
+                        <label htmlFor="slug">Slug</label>
+                        <input
+                            id="slug"
+                            value={data.slug}
+                            onChange={(e) => setData('slug', e.target.value)}
+                            className="w-full rounded border px-3 py-2"
+                        />
+                    </div>
+                    <div>
+                        <label htmlFor="channel">Channel</label>
+                        <select
+                            id="channel"
+                            value={data.channel}
+                            onChange={(e) => setData('channel', e.target.value)}
+                            className="w-full rounded border px-3 py-2"
+                        >
+                            {channels.map((c) => (
+                                <option key={c.value} value={c.value}>
+                                    {c.label}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <div>
+                        <label htmlFor="excerpt">Excerpt</label>
+                        <textarea
+                            id="excerpt"
+                            value={data.excerpt}
+                            onChange={(e) => setData('excerpt', e.target.value)}
+                            rows={2}
+                            className="w-full rounded border px-3 py-2"
+                        />
+                    </div>
+                    <div>
+                        <label htmlFor="body">Body</label>
+                        <textarea
+                            id="body"
+                            value={bodyText}
+                            onChange={(e) => updateContentText(e.target.value)}
+                            rows={10}
+                            className="w-full rounded border px-3 py-2 font-mono text-sm"
+                        />
+                        {errors.content && <p className="text-sm text-red-600">{errors.content}</p>}
+                    </div>
+                    <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
+                        {isNew ? 'Create draft' : 'Save'}
+                    </button>
+                </form>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Staff/Posts/Index.tsx
+++ b/resources/js/Pages/Staff/Posts/Index.tsx
@@ -1,0 +1,51 @@
+import { Head, Link } from '@inertiajs/react';
+
+type Post = {
+    id: number;
+    title: string;
+    slug: string;
+    status: string;
+    channel: string;
+    updated_at: string | null;
+    author: string;
+};
+
+export default function PostsIndex({ posts }: { posts: Post[] }) {
+    return (
+        <>
+            <Head title="Staff — Posts" />
+            <main className="mx-auto max-w-4xl px-6 py-12">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-2xl font-semibold">Posts</h1>
+                    <Link href="/staff/posts/new" className="rounded bg-apes-primary px-4 py-2 text-white">
+                        New draft
+                    </Link>
+                </div>
+                <table className="mt-8 w-full text-left text-sm">
+                    <thead>
+                        <tr className="border-b">
+                            <th className="py-2">Title</th>
+                            <th>Status</th>
+                            <th>Channel</th>
+                            <th>Updated</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {posts.map((post) => (
+                            <tr key={post.id} className="border-b">
+                                <td className="py-3">
+                                    <Link href={`/staff/posts/${post.id}/edit`} className="font-medium hover:underline">
+                                        {post.title}
+                                    </Link>
+                                </td>
+                                <td>{post.status}</td>
+                                <td>{post.channel}</td>
+                                <td>{post.updated_at ? new Date(post.updated_at).toLocaleDateString('en-GB') : '—'}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/home.tsx
+++ b/resources/js/Pages/home.tsx
@@ -1,23 +1,89 @@
-import { Head } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
 
-/**
- * Placeholder landing page.
- *
- * The real homepage - mission-led hero, featured/recent stories across the
- * three APES channels - lands with issue #6, built against the approved
- * design from issue #2. This exists so the Laravel foundation (issue #3)
- * has one real, working Inertia page to verify the stack end to end.
- */
-export default function Home() {
+type PostCard = {
+    title: string;
+    slug: string;
+    excerpt: string | null;
+    channel: string;
+    channel_slug: string;
+    author: string;
+    published_at: string | null;
+};
+
+type Channel = { slug: string; label: string };
+
+export default function Home({
+    featured,
+    recent,
+    channels,
+}: {
+    featured?: PostCard;
+    recent: PostCard[];
+    channels: Channel[];
+}) {
     return (
         <>
             <Head title="Home" />
-            <main className="mx-auto flex min-h-screen max-w-2xl flex-col items-start justify-center gap-4 px-6">
-                <h1 className="text-3xl font-semibold text-neutral-900">APES Newsroom</h1>
-                <p className="text-neutral-600">
-                    Laravel 13 + Inertia + React foundation is running. The public newsroom, publishing
-                    workflow, and authenticated workspaces build on top of this in later issues.
-                </p>
+            <a href="#main-content" className="sr-only focus:not-sr-only">
+                Skip to main content
+            </a>
+            <header className="border-b border-neutral-200 bg-white">
+                <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+                    <Link href="/" className="text-xl font-semibold text-apes-primary">
+                        APES Newsroom
+                    </Link>
+                    <nav className="flex gap-4 text-sm">
+                        {channels.map((c) => (
+                            <Link key={c.slug} href={`/${c.slug}`} className="text-neutral-600 hover:text-neutral-900">
+                                {c.label}
+                            </Link>
+                        ))}
+                        <Link href="/search" className="text-neutral-600 hover:text-neutral-900">
+                            Search
+                        </Link>
+                    </nav>
+                </div>
+            </header>
+
+            <main id="main-content" className="mx-auto max-w-5xl px-6 py-12">
+                <section className="mb-12">
+                    <h1 className="text-4xl font-semibold text-neutral-900">Mission-led stories from APES</h1>
+                    <p className="mt-3 max-w-2xl text-lg text-neutral-600">
+                        News and updates from APES CIC, Shelter &amp; Rescue, and Pet Care Clinic.
+                    </p>
+                </section>
+
+                {featured && (
+                    <section className="mb-12">
+                        <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-neutral-600">Featured</h2>
+                        <article className="rounded-lg border border-neutral-200 bg-white p-6">
+                            <p className="text-sm text-apes-primary">{featured.channel}</p>
+                            <h3 className="mt-2 text-2xl font-semibold">
+                                <Link href={`/articles/${featured.slug}`}>{featured.title}</Link>
+                            </h3>
+                            {featured.excerpt && <p className="mt-2 text-neutral-600">{featured.excerpt}</p>}
+                        </article>
+                    </section>
+                )}
+
+                <section>
+                    <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-neutral-600">Recent stories</h2>
+                    {recent.length === 0 ? (
+                        <p className="text-neutral-600">No published stories yet.</p>
+                    ) : (
+                        <ul className="grid gap-6 sm:grid-cols-2">
+                            {recent.map((post) => (
+                                <li key={post.slug} className="rounded-lg border border-neutral-200 bg-white p-5">
+                                    <p className="text-sm text-neutral-600">{post.channel}</p>
+                                    <h3 className="mt-1 text-lg font-semibold">
+                                        <Link href={`/articles/${post.slug}`}>{post.title}</Link>
+                                    </h3>
+                                    {post.excerpt && <p className="mt-2 text-sm text-neutral-600">{post.excerpt}</p>}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </section>
             </main>
         </>
     );

--- a/resources/views/rss.blade.php
+++ b/resources/views/rss.blade.php
@@ -1,0 +1,20 @@
+<?php echo '<?xml version="1.0" encoding="UTF-8"?>'; ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{{ config('app.name') }}</title>
+        <link>{{ url('/') }}</link>
+        <description>APES Newsroom — stories from APES CIC, Shelter &amp; Rescue, and Pet Care Clinic</description>
+        <language>en-gb</language>
+        <atom:link href="{{ url('/rss.xml') }}" rel="self" type="application/rss+xml" />
+        @foreach ($posts as $post)
+        <item>
+            <title>{{ $post->title }}</title>
+            <link>{{ url('/articles/'.$post->slug) }}</link>
+            <guid isPermaLink="true">{{ url('/articles/'.$post->slug) }}</guid>
+            <pubDate>{{ $post->published_at->toRfc2822String() }}</pubDate>
+            <description><![CDATA[{{ $post->excerpt }}]]></description>
+            <author>{{ $post->author->email }} ({{ $post->author->name }})</author>
+        </item>
+        @endforeach
+    </channel>
+</rss>

--- a/resources/views/sitemap.blade.php
+++ b/resources/views/sitemap.blade.php
@@ -1,0 +1,20 @@
+<?php echo '<?xml version="1.0" encoding="UTF-8"?>'; ?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>{{ url('/') }}</loc>
+        <changefreq>daily</changefreq>
+    </url>
+    @foreach (['apes-cic', 'apes-shelter-rescue', 'apes-pet-care-clinic'] as $channel)
+    <url>
+        <loc>{{ url('/'.$channel) }}</loc>
+        <changefreq>daily</changefreq>
+    </url>
+    @endforeach
+    @foreach ($posts as $post)
+    <url>
+        <loc>{{ url('/articles/'.$post->slug) }}</loc>
+        <lastmod>{{ ($post->updated_at ?? $post->published_at)->toAtomString() }}</lastmod>
+        <changefreq>weekly</changefreq>
+    </url>
+    @endforeach
+</urlset>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\Auth\CloudronOidcController;
+use App\Http\Controllers\Auth\EmailVerificationController;
 use App\Http\Controllers\Auth\MagicLinkController;
 use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
@@ -33,4 +34,12 @@ Route::middleware('guest')->group(function () {
 
 Route::middleware('auth')->group(function () {
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
+
+    Route::get('verify-email', [EmailVerificationController::class, 'notice'])->name('verification.notice');
+    Route::get('verify-email/{id}/{hash}', [EmailVerificationController::class, 'verify'])
+        ->middleware(['signed', 'throttle:6,1'])
+        ->name('verification.verify');
+    Route::post('email/verification-notification', [EmailVerificationController::class, 'store'])
+        ->middleware('throttle:6,1')
+        ->name('verification.send');
 });

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,11 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('staff:reconcile-roles')->daily();
+Schedule::command('posts:publish-scheduled')->everyMinute();

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,16 +1,49 @@
 <?php
 
+use App\Http\Controllers\AccountController;
+use App\Http\Controllers\ArticleController;
+use App\Http\Controllers\ChannelController;
 use App\Http\Controllers\HealthController;
+use App\Http\Controllers\HomeController;
+use App\Http\Controllers\RssController;
+use App\Http\Controllers\SearchController;
+use App\Http\Controllers\SitemapController;
+use App\Http\Controllers\Staff\PostController as StaffPostController;
+use App\Enums\Role;
 use Illuminate\Support\Facades\Route;
-use Inertia\Inertia;
 
-Route::get('/', function () {
-    return Inertia::render('home');
-})->name('home');
+Route::get('/', HomeController::class)->name('home');
 
-// Deliberately public and unauthenticated: Cloudron and external uptime
-// monitors call this. See App\Http\Controllers\HealthController for what
-// it does and does not expose.
 Route::get('/health', HealthController::class)->name('health');
+Route::get('/sitemap.xml', [SitemapController::class, 'index'])->name('sitemap');
+Route::get('/rss.xml', [RssController::class, 'index'])->name('rss');
+
+Route::get('/search', [SearchController::class, 'index'])->name('search');
+Route::get('/articles/{slug}', [ArticleController::class, 'show'])->name('articles.show');
+Route::get('/{channel}', [ChannelController::class, 'show'])
+    ->where('channel', 'apes-cic|apes-shelter-rescue|apes-pet-care-clinic')
+    ->name('channels.show');
+
+Route::middleware(['auth', 'verified'])->prefix('account')->name('account.')->group(function () {
+    Route::get('/', [AccountController::class, 'show'])->name('show');
+    Route::patch('/', [AccountController::class, 'update'])->name('update');
+    Route::get('/export', [AccountController::class, 'export'])->name('export');
+    Route::delete('/', [AccountController::class, 'destroy'])->name('destroy');
+});
+
+Route::middleware(['auth', 'verified', 'role:'.Role::Staff->value])
+    ->prefix('staff')
+    ->name('staff.')
+    ->group(function () {
+        Route::get('/posts', [StaffPostController::class, 'index'])->name('posts.index');
+        Route::get('/posts/new', [StaffPostController::class, 'create'])->name('posts.create');
+        Route::post('/posts', [StaffPostController::class, 'store'])->name('posts.store');
+        Route::get('/posts/{post}/edit', [StaffPostController::class, 'edit'])->name('posts.edit');
+        Route::patch('/posts/{post}', [StaffPostController::class, 'update'])->name('posts.update');
+        Route::post('/posts/{post}/submit', [StaffPostController::class, 'submitForReview'])->name('posts.submit');
+        Route::post('/posts/{post}/schedule', [StaffPostController::class, 'schedule'])->name('posts.schedule');
+        Route::post('/posts/{post}/publish', [StaffPostController::class, 'publish'])->name('posts.publish');
+        Route::get('/posts/{post}/preview', [StaffPostController::class, 'preview'])->name('posts.preview');
+    });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AccountTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_update_profile(): void
+    {
+        $user = User::factory()->create(['name' => 'Old Name']);
+
+        $this->actingAs($user)
+            ->patch(route('account.update'), ['name' => 'New Name', 'email' => $user->email])
+            ->assertRedirect();
+
+        $this->assertSame('New Name', $user->fresh()->name);
+    }
+
+    public function test_user_can_export_account_data(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('account.export'));
+
+        $response->assertOk();
+        $response->assertHeader('content-type', 'application/json');
+        $this->assertStringContainsString($user->email, $response->streamedContent());
+    }
+
+    public function test_user_can_delete_account(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->delete(route('account.destroy'))
+            ->assertRedirect(route('home'));
+
+        $this->assertGuest();
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    }
+}

--- a/tests/Feature/Auth/CloudronOidcCallbackSuccessTest.php
+++ b/tests/Feature/Auth/CloudronOidcCallbackSuccessTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Enums\Role;
+use App\Models\User;
+use App\Services\Auth\CloudronOidcProvider;
+use App\Services\Auth\LdapGroupLookup;
+use App\Services\Auth\StaffOidcIdentity;
+use App\Services\Auth\StaffReconcileResult;
+use App\Services\Auth\StaffReconciler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class CloudronOidcCallbackSuccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_successful_callback_logs_in_staff_user(): void
+    {
+        $provider = Mockery::mock(CloudronOidcProvider::class);
+        $provider->shouldReceive('exchangeCodeForIdentity')
+            ->with('valid-code')
+            ->andReturn(new StaffOidcIdentity(sub: 'oidc-1', email: 'staff@example.com', name: 'Staff User'));
+        $this->app->instance(CloudronOidcProvider::class, $provider);
+
+        $reconciler = Mockery::mock(StaffReconciler::class);
+        $user = User::factory()->staff()->create(['external_id' => 'oidc-1', 'email' => 'staff@example.com']);
+        $reconciler->shouldReceive('reconcile')
+            ->andReturn(StaffReconcileResult::allow($user));
+        $this->app->instance(StaffReconciler::class, $reconciler);
+
+        $response = $this->withSession(['cloudron_oidc_state' => 'test-state'])
+            ->get('/auth/cloudron/callback?code=valid-code&state=test-state');
+
+        $response->assertRedirect(route('home'));
+        $this->assertAuthenticatedAs($user);
+    }
+}

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class EmailVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_registration_redirects_to_verification_notice(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertRedirect(route('verification.notice'));
+        $this->assertAuthenticated();
+        $this->assertNull(auth()->user()->email_verified_at);
+    }
+
+    public function test_unverified_user_cannot_access_account(): void
+    {
+        $user = User::factory()->unverified()->create();
+
+        $this->actingAs($user)
+            ->get(route('account.show'))
+            ->assertRedirect(route('verification.notice'));
+    }
+
+    public function test_verified_user_can_access_account(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('account.show'))
+            ->assertOk();
+    }
+
+    public function test_email_can_be_verified(): void
+    {
+        Event::fake([Verified::class]);
+
+        $user = User::factory()->unverified()->create();
+
+        $verificationUrl = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $user->id, 'hash' => sha1($user->email)]
+        );
+
+        $this->actingAs($user)
+            ->get($verificationUrl)
+            ->assertRedirect(route('account.show'));
+
+        $this->assertTrue($user->fresh()->hasVerifiedEmail());
+        Event::assertDispatched(Verified::class);
+    }
+
+    public function test_staff_oidc_users_are_considered_verified(): void
+    {
+        $user = User::factory()->staff()->create(['email_verified_at' => null]);
+
+        $this->assertTrue($user->hasVerifiedEmail());
+    }
+}

--- a/tests/Feature/Auth/PublicRegistrationTest.php
+++ b/tests/Feature/Auth/PublicRegistrationTest.php
@@ -20,7 +20,7 @@ class PublicRegistrationTest extends TestCase
             'password_confirmation' => 'password',
         ]);
 
-        $response->assertRedirect(route('home'));
+        $response->assertRedirect(route('verification.notice'));
         $this->assertAuthenticated();
 
         $user = User::where('email', 'jamie@example.com')->firstOrFail();

--- a/tests/Feature/Auth/ReconcileStaffRolesCommandTest.php
+++ b/tests/Feature/Auth/ReconcileStaffRolesCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Enums\Role;
+use App\Models\User;
+use App\Services\Auth\LdapGroupLookup;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class ReconcileStaffRolesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_demotes_staff_without_recognised_groups(): void
+    {
+        $user = User::factory()->admin()->create(['email' => 'staffer@example.com']);
+
+        $lookup = Mockery::mock(LdapGroupLookup::class);
+        $lookup->shouldReceive('groupsForEmail')->with('staffer@example.com')->andReturn([]);
+        $this->app->instance(LdapGroupLookup::class, $lookup);
+
+        $this->artisan('staff:reconcile-roles')->assertSuccessful();
+
+        $this->assertSame(Role::Public, $user->fresh()->role);
+    }
+
+    public function test_command_updates_role_when_ldap_membership_changes(): void
+    {
+        $user = User::factory()->staff()->create(['email' => 'staffer@example.com']);
+
+        $lookup = Mockery::mock(LdapGroupLookup::class);
+        $lookup->shouldReceive('groupsForEmail')->with('staffer@example.com')->andReturn(['newsroom-admins']);
+        $this->app->instance(LdapGroupLookup::class, $lookup);
+
+        $this->artisan('staff:reconcile-roles')->assertSuccessful();
+
+        $this->assertSame(Role::Admin, $user->fresh()->role);
+    }
+}

--- a/tests/Feature/HomePageTest.php
+++ b/tests/Feature/HomePageTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
 
 class HomePageTest extends TestCase
 {
+    use RefreshDatabase;
     public function test_the_homepage_renders_via_inertia(): void
     {
         $response = $this->get('/');

--- a/tests/Feature/PublicNewsroomTest.php
+++ b/tests/Feature/PublicNewsroomTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Post;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PublicNewsroomTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_published_article_is_visible(): void
+    {
+        $post = Post::factory()->published()->create(['slug' => 'visible-story']);
+
+        $this->get('/articles/visible-story')->assertOk();
+    }
+
+    public function test_draft_article_is_not_visible(): void
+    {
+        Post::factory()->create(['slug' => 'hidden-draft']);
+
+        $this->get('/articles/hidden-draft')->assertNotFound();
+    }
+
+    public function test_sitemap_returns_xml(): void
+    {
+        Post::factory()->published()->create();
+
+        $response = $this->get('/sitemap.xml');
+
+        $response->assertOk();
+        $response->assertHeader('content-type', 'application/xml');
+    }
+
+    public function test_rss_returns_xml(): void
+    {
+        Post::factory()->published()->create();
+
+        $response = $this->get('/rss.xml');
+
+        $response->assertOk();
+        $response->assertHeader('content-type', 'application/rss+xml');
+    }
+
+    public function test_channel_page_renders(): void
+    {
+        $this->get('/apes-cic')->assertOk();
+    }
+
+    public function test_search_finds_published_posts(): void
+    {
+        Post::factory()->published()->create(['title' => 'Unique Searchable Title']);
+
+        $this->get('/search?q=Unique+Searchable')->assertOk();
+    }
+}

--- a/tests/Feature/PublishScheduledPostsCommandTest.php
+++ b/tests/Feature/PublishScheduledPostsCommandTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\PostStatus;
+use App\Models\Post;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PublishScheduledPostsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_scheduled_posts_are_published_when_due(): void
+    {
+        $post = Post::factory()->create([
+            'status' => PostStatus::Scheduled,
+            'scheduled_for' => now('Europe/London')->subMinute(),
+        ]);
+
+        $this->artisan('posts:publish-scheduled')->assertSuccessful();
+
+        $post->refresh();
+        $this->assertSame(PostStatus::Published, $post->status);
+        $this->assertNotNull($post->published_at);
+    }
+}

--- a/tests/Feature/StaffPostTest.php
+++ b/tests/Feature/StaffPostTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\PostStatus;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StaffPostTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_staff_can_create_a_draft(): void
+    {
+        $staff = User::factory()->staff()->create();
+
+        $response = $this->actingAs($staff)->post('/staff/posts', [
+            'title' => 'Test Article',
+            'slug' => 'test-article',
+            'excerpt' => 'An excerpt',
+            'channel' => 'apes_cic',
+            'content' => [
+                'blocks' => [['type' => 'paragraph', 'data' => ['text' => 'Body text']]],
+            ],
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('posts', ['slug' => 'test-article', 'status' => PostStatus::Draft->value]);
+    }
+
+    public function test_public_user_cannot_access_staff_posts(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->get('/staff/posts')->assertForbidden();
+    }
+
+    public function test_admin_can_publish_post(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->create(['author_id' => $admin->id]);
+
+        $this->actingAs($admin)->post("/staff/posts/{$post->id}/publish")->assertRedirect();
+
+        $this->assertSame(PostStatus::Published, $post->fresh()->status);
+    }
+}

--- a/tests/Unit/BlockValidatorTest.php
+++ b/tests/Unit/BlockValidatorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\EditorJs\BlockValidator;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class BlockValidatorTest extends TestCase
+{
+    public function test_valid_paragraph_block_passes(): void
+    {
+        $result = (new BlockValidator)->validate([
+            'blocks' => [['type' => 'paragraph', 'data' => ['text' => 'Hello world']]],
+        ]);
+
+        $this->assertCount(1, $result['blocks']);
+    }
+
+    public function test_script_in_text_is_rejected(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        (new BlockValidator)->validate([
+            'blocks' => [['type' => 'paragraph', 'data' => ['text' => '<script>alert(1)</script>']]],
+        ]);
+    }
+
+    public function test_disallowed_block_type_is_rejected(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        (new BlockValidator)->validate([
+            'blocks' => [['type' => 'raw', 'data' => ['html' => '<p>x</p>']]],
+        ]);
+    }
+
+    public function test_image_requires_alt_text(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        (new BlockValidator)->validate([
+            'blocks' => [[
+                'type' => 'image',
+                'data' => ['file' => ['url' => 'https://example.com/img.jpg']],
+            ]],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Completes remaining issue #4 work: email verification, account profile/export/deletion, scheduled staff role reconciliation, and OIDC callback integration test
- Adds first-pass design artifacts for issue #2 in \docs/design/\
- Adds beta deployment acceptance checklist for issue #3 in \docs/deployment-beta-acceptance.md\
- Implements publishing foundation for issue #5: post schema, Editor.js block validation, staff draft workflow, scheduling command, and preview
- Implements public newsroom foundation for issue #6: homepage, channel pages, articles, search, RSS, and sitemap

## Test plan
- [x] \php artisan test\ (81 tests passing)
- [x] \
pm run typecheck\
- [x] \
pm run build\
- [ ] Watched beta deploy using \docs/deployment-beta-acceptance.md\ (requires Cloudron credentials)
- [ ] Manual smoke test of staff post create/edit/preview/publish flow
- [ ] Manual smoke test of public homepage, channel, article, search, RSS, and sitemap routes

Made with [Cursor](https://cursor.com)