### PR TITLE
chore: add composer lint/format scripts matching CI Pint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ that file and `.env.example` for what's mapped.
 ## Testing
 
 ```
+composer lint        # PHP style (Laravel Pint --test; same as CI)
+composer format      # auto-fix PHP style with Pint
 composer test        # or: php artisan test
 npm run typecheck
-npm run lint
+npm run lint         # ESLint on resources/js
 ```
 
 ## Health check

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,12 @@
             "@php artisan config:clear --ansi",
             "@php artisan test"
         ],
+        "lint": [
+            "@php vendor/bin/pint --test"
+        ],
+        "format": [
+            "@php vendor/bin/pint"
+        ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"


### PR DESCRIPTION
## Summary
- Adds \composer lint\ (\pint --test\) and \composer format\ (\pint\) so local PHP style matches CI
- Documents both commands in the README Testing section

## Test plan
- [x] \composer install\ + \
pm ci\
- [x] \composer lint\, \
pm run lint\, \
pm run typecheck\, \php artisan test\, \
pm run build\ all pass

Made with [Cursor](https://cursor.com)