### PR TITLE
feat: epic phase 3 — mailing lists and engagement (#7, #8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="newsroom@apesnews.org.uk"
 MAIL_FROM_NAME="${APP_NAME}"
 
+# Campaign throttle (recipients/minute). Default 60 until beta capacity testing.
+MAILING_THROTTLE_PER_MINUTE=60
+MAILING_CONTACT_ADDRESS="newsroom@apesnews.org.uk"
+
 VITE_APP_NAME="${APP_NAME}"
 
 # --- Cloudron addon variables (informational) --------------------------

--- a/app/Console/Commands/PublishScheduledPostsCommand.php
+++ b/app/Console/Commands/PublishScheduledPostsCommand.php
@@ -3,14 +3,23 @@
 namespace App\Console\Commands;
 
 use App\Enums\PostStatus;
+use App\Enums\Role;
 use App\Models\Post;
+use App\Models\User;
+use App\Services\Mailing\CampaignService;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 
 class PublishScheduledPostsCommand extends Command
 {
     protected $signature = 'posts:publish-scheduled';
 
     protected $description = 'Publish posts whose scheduled_for time has passed (Europe/London)';
+
+    public function __construct(private readonly CampaignService $campaigns)
+    {
+        parent::__construct();
+    }
 
     public function handle(): int
     {
@@ -20,12 +29,24 @@ class PublishScheduledPostsCommand extends Command
             ->where('scheduled_for', '<=', now('Europe/London'))
             ->get();
 
+        $systemActor = User::query()
+            ->where('role', Role::SuperAdmin)
+            ->orderBy('id')
+            ->first()
+            ?? User::query()->where('role', Role::Admin)->orderBy('id')->first();
+
         foreach ($posts as $post) {
-            $post->update([
-                'status' => PostStatus::Published,
-                'published_at' => $post->scheduled_for,
-                'scheduled_for' => null,
-            ]);
+            DB::transaction(function () use ($post, $systemActor) {
+                $post->update([
+                    'status' => PostStatus::Published,
+                    'published_at' => $post->scheduled_for,
+                    'scheduled_for' => null,
+                ]);
+
+                if ($systemActor) {
+                    $this->campaigns->createFromPublishedPost($post->fresh(), $systemActor);
+                }
+            });
 
             $this->line("Published: {$post->title}");
         }

--- a/app/Enums/CampaignRecipientStatus.php
+++ b/app/Enums/CampaignRecipientStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum CampaignRecipientStatus: string
+{
+    case Queued = 'queued';
+    case Accepted = 'accepted';
+    case Failed = 'failed';
+    case Skipped = 'skipped';
+}

--- a/app/Enums/CampaignStatus.php
+++ b/app/Enums/CampaignStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum CampaignStatus: string
+{
+    case Draft = 'draft';
+    case Queued = 'queued';
+    case Sending = 'sending';
+    case Completed = 'completed';
+    case Failed = 'failed';
+    case Cancelled = 'cancelled';
+}

--- a/app/Enums/ConsentAction.php
+++ b/app/Enums/ConsentAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum ConsentAction: string
+{
+    case SignupRequested = 'signup_requested';
+    case Confirmed = 'confirmed';
+    case Unsubscribed = 'unsubscribed';
+    case PreferenceUpdated = 'preference_updated';
+    case Suppressed = 'suppressed';
+}

--- a/app/Enums/MailingList.php
+++ b/app/Enums/MailingList.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+enum MailingList: string
+{
+    case ApesCic = 'apes_cic';
+    case ApesShelterRescue = 'apes_shelter_rescue';
+    case ApesPetCareClinic = 'apes_pet_care_clinic';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ApesCic => 'APES CIC',
+            self::ApesShelterRescue => 'APES Shelter & Rescue',
+            self::ApesPetCareClinic => 'APES Pet Care Clinic',
+        };
+    }
+
+    public function purpose(): string
+    {
+        return match ($this) {
+            self::ApesCic => 'News and updates from APES CIC about our charity work and campaigns.',
+            self::ApesShelterRescue => 'Updates from APES Shelter & Rescue about animals in our care and adoption news.',
+            self::ApesPetCareClinic => 'News from APES Pet Care Clinic about clinics, care advice, and services.',
+        };
+    }
+}

--- a/app/Enums/ModerationStatus.php
+++ b/app/Enums/ModerationStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+enum ModerationStatus: string
+{
+    case Private = 'private';
+    case Pending = 'pending';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+    case Suspended = 'suspended';
+
+    public function isPubliclyVisible(): bool
+    {
+        return $this === self::Approved;
+    }
+}

--- a/app/Enums/ReactionType.php
+++ b/app/Enums/ReactionType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+enum ReactionType: string
+{
+    case Helpful = 'helpful';
+    case Support = 'support';
+    case ThankYou = 'thank_you';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Helpful => 'Helpful',
+            self::Support => 'Support',
+            self::ThankYou => 'Thank You',
+        };
+    }
+}

--- a/app/Enums/SubscriptionStatus.php
+++ b/app/Enums/SubscriptionStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum SubscriptionStatus: string
+{
+    case Pending = 'pending';
+    case Confirmed = 'confirmed';
+    case Unsubscribed = 'unsubscribed';
+}

--- a/app/Http/Controllers/Admin/ModerationController.php
+++ b/app/Http/Controllers/Admin/ModerationController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Enums\ModerationStatus;
+use App\Enums\Role;
+use App\Http\Controllers\Controller;
+use App\Models\Comment;
+use App\Models\Profile;
+use App\Services\Engagement\CommentService;
+use App\Services\Engagement\ProfileService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ModerationController extends Controller
+{
+    public function __construct(
+        private readonly ProfileService $profiles,
+        private readonly CommentService $comments,
+    ) {}
+
+    public function index(Request $request): Response
+    {
+        $this->authorizeAdmin();
+
+        $pendingProfiles = Profile::query()
+            ->where('moderation_status', ModerationStatus::Pending)
+            ->with('user:id,name,email')
+            ->latest('updated_at')
+            ->get()
+            ->map(fn (Profile $profile) => [
+                'id' => $profile->id,
+                'display_name' => $profile->display_name,
+                'bio' => $profile->bio,
+                'user_name' => $profile->user->name,
+                'updated_at' => $profile->updated_at?->toIso8601String(),
+            ]);
+
+        $pendingComments = Comment::query()
+            ->where('moderation_status', ModerationStatus::Pending)
+            ->with(['user:id,name', 'post:id,title,slug'])
+            ->latest()
+            ->get()
+            ->map(fn (Comment $comment) => [
+                'id' => $comment->id,
+                'body' => $comment->body,
+                'user_name' => $comment->user->name,
+                'post_title' => $comment->post->title,
+                'post_slug' => $comment->post->slug,
+                'created_at' => $comment->created_at?->toIso8601String(),
+            ]);
+
+        return Inertia::render('Admin/Moderation/Index', [
+            'profiles' => $pendingProfiles,
+            'comments' => $pendingComments,
+        ]);
+    }
+
+    public function moderateProfile(Request $request, Profile $profile): RedirectResponse
+    {
+        $this->authorizeAdmin();
+
+        $validated = $request->validate([
+            'status' => ['required', Rule::in([
+                ModerationStatus::Approved->value,
+                ModerationStatus::Rejected->value,
+                ModerationStatus::Suspended->value,
+                ModerationStatus::Private->value,
+            ])],
+            'notes' => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $this->profiles->moderate(
+            $profile,
+            $request->user(),
+            ModerationStatus::from($validated['status']),
+            $validated['notes'] ?? null,
+        );
+
+        return back();
+    }
+
+    public function moderateComment(Request $request, Comment $comment): RedirectResponse
+    {
+        $this->authorizeAdmin();
+
+        $validated = $request->validate([
+            'status' => ['required', Rule::in([
+                ModerationStatus::Approved->value,
+                ModerationStatus::Rejected->value,
+            ])],
+            'notes' => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $this->comments->moderate(
+            $comment,
+            $request->user(),
+            ModerationStatus::from($validated['status']),
+            $validated['notes'] ?? null,
+        );
+
+        return back();
+    }
+
+    private function authorizeAdmin(): void
+    {
+        if (! request()->user()?->role->atLeast(Role::Admin)) {
+            abort(403);
+        }
+    }
+}

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -4,13 +4,21 @@ namespace App\Http\Controllers;
 
 use App\Models\Post;
 use App\Services\EditorJs\BlockRenderer;
+use App\Services\Engagement\CommentService;
+use App\Services\Engagement\ReactionService;
+use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class ArticleController extends Controller
 {
-    public function show(string $slug, BlockRenderer $renderer): Response
-    {
+    public function show(
+        Request $request,
+        string $slug,
+        BlockRenderer $renderer,
+        CommentService $comments,
+        ReactionService $reactions,
+    ): Response {
         $post = Post::published()
             ->where('slug', $slug)
             ->with('author', 'tags')
@@ -30,7 +38,11 @@ class ArticleController extends Controller
                 'meta_description' => $post->meta_description ?? $post->excerpt,
                 'tags' => $post->tags->pluck('name'),
             ],
+            'comments' => $comments->approvedPayloadForPost($post),
+            'reactions' => $reactions->countsForPost($post, $request->user()),
+            'canEngage' => $request->user()?->hasVerifiedEmail() ?? false,
             'preview' => false,
+            'status' => session('status'),
         ]);
     }
 }

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Comment;
+use App\Models\Post;
+use App\Services\Engagement\CommentService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class CommentController extends Controller
+{
+    public function __construct(private readonly CommentService $comments) {}
+
+    public function store(Request $request, string $slug): RedirectResponse
+    {
+        $post = Post::published()->where('slug', $slug)->firstOrFail();
+
+        $validated = $request->validate([
+            'body' => ['required', 'string', 'max:2000'],
+        ]);
+
+        $this->comments->create($request->user(), $post, $validated['body']);
+
+        return back()->with('status', 'comment-pending');
+    }
+
+    public function update(Request $request, Comment $comment): RedirectResponse
+    {
+        $validated = $request->validate([
+            'body' => ['required', 'string', 'max:2000'],
+        ]);
+
+        $this->comments->update($request->user(), $comment, $validated['body']);
+
+        return back()->with('status', 'comment-pending');
+    }
+}

--- a/app/Http/Controllers/Mailing/ConfirmController.php
+++ b/app/Http/Controllers/Mailing/ConfirmController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Mailing;
+
+use App\Http\Controllers\Controller;
+use App\Services\Mailing\ConsentService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ConfirmController extends Controller
+{
+    public function __construct(private readonly ConsentService $consent) {}
+
+    public function __invoke(Request $request, string $token): Response|RedirectResponse
+    {
+        $subscription = $this->consent->confirm(
+            $token,
+            $request->ip(),
+            $request->userAgent(),
+        );
+
+        return Inertia::render('Mailing/Confirmed', [
+            'list' => $subscription->list->label(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Mailing/PreferenceController.php
+++ b/app/Http/Controllers/Mailing/PreferenceController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Controllers\Mailing;
+
+use App\Enums\MailingList;
+use App\Http\Controllers\Controller;
+use App\Services\Mailing\ConsentService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PreferenceController extends Controller
+{
+    public function __construct(private readonly ConsentService $consent) {}
+
+    public function showSigned(Request $request): Response
+    {
+        abort_unless($request->hasValidSignature(), 403);
+
+        $email = strtolower((string) $request->query('email'));
+
+        return Inertia::render('Mailing/Preferences', [
+            'email' => $email,
+            'lists' => array_values($this->consent->preferenceStateForEmail($email)),
+            'signed' => true,
+        ]);
+    }
+
+    public function showAccount(Request $request): Response
+    {
+        $email = strtolower($request->user()->email);
+
+        return Inertia::render('Mailing/Preferences', [
+            'email' => $email,
+            'lists' => array_values($this->consent->preferenceStateForEmail($email)),
+            'signed' => false,
+        ]);
+    }
+
+    public function updateSigned(Request $request): RedirectResponse
+    {
+        abort_unless($request->hasValidSignature(), 403);
+
+        $email = strtolower((string) $request->query('email'));
+        $validated = $request->validate([
+            'lists' => ['array'],
+            'lists.*' => [Rule::enum(MailingList::class)],
+        ]);
+
+        $selected = $validated['lists'] ?? [];
+        $current = $this->consent->preferenceStateForEmail($email);
+
+        foreach (MailingList::cases() as $list) {
+            $wants = in_array($list->value, $selected, true);
+            $status = $current[$list->value]['status'] ?? null;
+
+            if ($wants && $status !== 'confirmed' && $status !== 'pending') {
+                $this->consent->signup(
+                    email: $email,
+                    lists: [$list->value],
+                    source: 'signed_preferences',
+                    ip: $request->ip(),
+                    userAgent: $request->userAgent(),
+                );
+            } elseif (! $wants && in_array($status, ['confirmed', 'pending'], true)) {
+                $this->consent->unsubscribe(
+                    email: $email,
+                    list: $list,
+                    source: 'signed_preferences',
+                    ip: $request->ip(),
+                    userAgent: $request->userAgent(),
+                );
+            }
+        }
+
+        return back()->with('status', 'preferences-updated');
+    }
+
+    public function updateAccount(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'lists' => ['array'],
+            'lists.*' => [Rule::enum(MailingList::class)],
+        ]);
+
+        $this->consent->syncAccountPreferences(
+            $request->user(),
+            $validated['lists'] ?? [],
+            $request->ip(),
+            $request->userAgent(),
+        );
+
+        return back()->with('status', 'preferences-updated');
+    }
+}

--- a/app/Http/Controllers/Mailing/SignupController.php
+++ b/app/Http/Controllers/Mailing/SignupController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Mailing;
+
+use App\Enums\MailingList;
+use App\Http\Controllers\Controller;
+use App\Services\Mailing\ConsentService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SignupController extends Controller
+{
+    public function __construct(private readonly ConsentService $consent) {}
+
+    public function show(): Response
+    {
+        return Inertia::render('Mailing/Signup', [
+            'lists' => $this->listOptions(),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'email' => ['required', 'email', 'max:255'],
+            'lists' => ['required', 'array', 'min:1'],
+            'lists.*' => [Rule::enum(MailingList::class)],
+        ]);
+
+        $this->consent->signup(
+            email: $validated['email'],
+            lists: $validated['lists'],
+            source: 'public_signup',
+            user: $request->user(),
+            ip: $request->ip(),
+            userAgent: $request->userAgent(),
+        );
+
+        return back()->with('status', 'check-email');
+    }
+
+    /**
+     * @return list<array{value: string, label: string, purpose: string}>
+     */
+    private function listOptions(): array
+    {
+        return collect(MailingList::cases())->map(fn (MailingList $list) => [
+            'value' => $list->value,
+            'label' => $list->label(),
+            'purpose' => $list->purpose(),
+        ])->all();
+    }
+}

--- a/app/Http/Controllers/Mailing/UnsubscribeController.php
+++ b/app/Http/Controllers/Mailing/UnsubscribeController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Mailing;
+
+use App\Enums\MailingList;
+use App\Http\Controllers\Controller;
+use App\Services\Mailing\ConsentService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+
+class UnsubscribeController extends Controller
+{
+    public function __construct(private readonly ConsentService $consent) {}
+
+    public function show(Request $request): \Inertia\Response
+    {
+        abort_unless($request->hasValidSignature(), 403);
+
+        $email = strtolower((string) $request->query('email'));
+
+        return Inertia::render('Mailing/Unsubscribe', [
+            'email' => $email,
+            'lists' => collect(MailingList::cases())->map(fn (MailingList $list) => [
+                'value' => $list->value,
+                'label' => $list->label(),
+            ])->all(),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse|Response
+    {
+        abort_unless($request->hasValidSignature(), 403);
+
+        $email = strtolower((string) $request->query('email'));
+
+        $validated = $request->validate([
+            'list' => ['nullable', Rule::enum(MailingList::class)],
+            'all' => ['sometimes', 'boolean'],
+        ]);
+
+        $list = isset($validated['list'])
+            ? MailingList::from($validated['list'])
+            : null;
+
+        if ($request->boolean('all') || $list === null) {
+            $this->consent->unsubscribe(
+                email: $email,
+                list: null,
+                source: 'unsubscribe_link',
+                ip: $request->ip(),
+                userAgent: $request->userAgent(),
+            );
+        } else {
+            $this->consent->unsubscribe(
+                email: $email,
+                list: $list,
+                source: 'unsubscribe_link',
+                ip: $request->ip(),
+                userAgent: $request->userAgent(),
+            );
+        }
+
+        // RFC 8058 one-click unsubscribe may POST without a body expecting 200.
+        if ($request->expectsJson() || $request->header('List-Unsubscribe') === 'One-Click') {
+            return response()->noContent();
+        }
+
+        return redirect()->route('home')->with('status', 'unsubscribed');
+    }
+
+    /**
+     * One-click POST endpoint (List-Unsubscribe-Post).
+     */
+    public function oneClick(Request $request): Response
+    {
+        abort_unless($request->hasValidSignature(), 403);
+
+        $email = strtolower((string) $request->query('email'));
+
+        $this->consent->unsubscribe(
+            email: $email,
+            list: null,
+            source: 'list_unsubscribe_one_click',
+            ip: $request->ip(),
+            userAgent: $request->userAgent(),
+        );
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Profile;
+use App\Services\Engagement\ProfileService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ProfileController extends Controller
+{
+    public function __construct(private readonly ProfileService $profiles) {}
+
+    public function edit(Request $request): Response
+    {
+        $profile = $this->profiles->forUser($request->user());
+
+        return Inertia::render('Account/PublicProfile', [
+            'profile' => [
+                'display_name' => $profile->display_name,
+                'bio' => $profile->bio,
+                'avatar_url' => $profile->avatar_path ? url('/storage/'.$profile->avatar_path) : null,
+                'public_opt_in' => $profile->public_opt_in,
+                'moderation_status' => $profile->moderation_status->value,
+                'moderation_notes' => $profile->moderation_status->value === 'rejected'
+                    ? $profile->moderation_notes
+                    : null,
+            ],
+            'status' => session('status'),
+        ]);
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'display_name' => ['nullable', 'string', 'max:80'],
+            'bio' => ['nullable', 'string', 'max:500'],
+            'public_opt_in' => ['sometimes', 'boolean'],
+            'avatar' => ['nullable', 'image', 'max:2048', 'mimes:jpg,jpeg,png,webp'],
+        ]);
+
+        $this->profiles->update(
+            $request->user(),
+            [
+                'display_name' => $validated['display_name'] ?? null,
+                'bio' => $validated['bio'] ?? null,
+                'public_opt_in' => $request->boolean('public_opt_in'),
+            ],
+            $request->file('avatar'),
+        );
+
+        return back()->with('status', 'profile-submitted');
+    }
+
+    public function show(string $id): Response
+    {
+        $profile = Profile::query()->with('user')->findOrFail($id);
+        $payload = $profile->publicPayload();
+
+        abort_unless($payload !== null, 404);
+
+        return Inertia::render('Profiles/Show', [
+            'profile' => $payload,
+        ]);
+    }
+}

--- a/app/Http/Controllers/ReactionController.php
+++ b/app/Http/Controllers/ReactionController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\ReactionType;
+use App\Models\Post;
+use App\Services\Engagement\ReactionService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class ReactionController extends Controller
+{
+    public function __construct(private readonly ReactionService $reactions) {}
+
+    public function toggle(Request $request, string $slug): RedirectResponse
+    {
+        $post = Post::published()->where('slug', $slug)->firstOrFail();
+
+        $validated = $request->validate([
+            'type' => ['required', Rule::enum(ReactionType::class)],
+        ]);
+
+        $this->reactions->toggle(
+            $request->user(),
+            $post,
+            ReactionType::from($validated['type']),
+        );
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Staff/CampaignController.php
+++ b/app/Http/Controllers/Staff/CampaignController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Staff;
+
+use App\Enums\Role;
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+use App\Services\Mailing\CampaignService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class CampaignController extends Controller
+{
+    public function __construct(private readonly CampaignService $campaigns) {}
+
+    public function preview(Request $request, Post $post): Response
+    {
+        $this->authorizeAdmin();
+
+        return Inertia::render('Staff/Campaigns/Preview', [
+            'post' => [
+                'id' => $post->id,
+                'title' => $post->title,
+                'status' => $post->status->value,
+                'email_on_publish' => $post->email_on_publish,
+                'mailing_lists' => $post->mailing_lists ?? [],
+            ],
+            'snapshot' => $this->campaigns->previewPayload($post),
+        ]);
+    }
+
+    public function testSend(Request $request, Post $post): RedirectResponse
+    {
+        $this->authorizeAdmin();
+
+        $validated = $request->validate([
+            'email' => ['required', 'email', 'max:255'],
+        ]);
+
+        $this->campaigns->createTestSend($post, $request->user(), $validated['email']);
+
+        return back()->with('status', 'test-send-queued');
+    }
+
+    private function authorizeAdmin(): void
+    {
+        if (! request()->user()->role->atLeast(Role::Admin)) {
+            abort(403);
+        }
+    }
+}

--- a/app/Http/Controllers/Staff/PostController.php
+++ b/app/Http/Controllers/Staff/PostController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Staff;
 
 use App\Enums\Channel;
+use App\Enums\MailingList;
 use App\Enums\PostStatus;
 use App\Enums\Role;
 use App\Http\Controllers\Controller;
@@ -12,8 +13,10 @@ use App\Models\Post;
 use App\Models\PostRevision;
 use App\Services\EditorJs\BlockRenderer;
 use App\Services\EditorJs\BlockValidator;
+use App\Services\Mailing\CampaignService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -23,6 +26,7 @@ class PostController extends Controller
     public function __construct(
         private readonly BlockValidator $validator,
         private readonly BlockRenderer $renderer,
+        private readonly CampaignService $campaigns,
     ) {}
 
     public function index(Request $request): Response
@@ -51,6 +55,7 @@ class PostController extends Controller
         return Inertia::render('Staff/Posts/Edit', [
             'post' => null,
             'channels' => $this->channelOptions(),
+            'mailingLists' => $this->mailingListOptions(),
         ]);
     }
 
@@ -88,8 +93,11 @@ class PostController extends Controller
                 'meta_title' => $post->meta_title,
                 'meta_description' => $post->meta_description,
                 'scheduled_for' => $post->scheduled_for?->format('Y-m-d\TH:i'),
+                'email_on_publish' => $post->email_on_publish,
+                'mailing_lists' => $post->mailing_lists ?? [],
             ],
             'channels' => $this->channelOptions(),
+            'mailingLists' => $this->mailingListOptions(),
         ]);
     }
 
@@ -141,11 +149,15 @@ class PostController extends Controller
             return back();
         }
 
-        $post->update([
-            'status' => PostStatus::Published,
-            'published_at' => now(),
-            'scheduled_for' => null,
-        ]);
+        DB::transaction(function () use ($request, $post) {
+            $post->update([
+                'status' => PostStatus::Published,
+                'published_at' => now(),
+                'scheduled_for' => null,
+            ]);
+
+            $this->campaigns->createFromPublishedPost($post->fresh(), $request->user());
+        });
 
         return back();
     }
@@ -157,6 +169,14 @@ class PostController extends Controller
         return Inertia::render('Articles/Show', [
             'article' => $this->articlePayload($post),
             'preview' => true,
+            'comments' => [],
+            'reactions' => [
+                'helpful' => 0,
+                'support' => 0,
+                'thank_you' => 0,
+                'mine' => [],
+            ],
+            'canEngage' => false,
         ]);
     }
 
@@ -192,6 +212,17 @@ class PostController extends Controller
         return collect(Channel::cases())->map(fn (Channel $c) => [
             'value' => $c->value,
             'label' => $c->label(),
+        ])->all();
+    }
+
+    /**
+     * @return array<int, array{value: string, label: string}>
+     */
+    private function mailingListOptions(): array
+    {
+        return collect(MailingList::cases())->map(fn (MailingList $list) => [
+            'value' => $list->value,
+            'label' => $list->label(),
         ])->all();
     }
 

--- a/app/Http/Requests/Staff/StorePostRequest.php
+++ b/app/Http/Requests/Staff/StorePostRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Staff;
 
 use App\Enums\Channel;
+use App\Enums\MailingList;
 use App\Enums\Role;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -27,6 +28,9 @@ class StorePostRequest extends FormRequest
             'channel' => ['required', Rule::enum(Channel::class)],
             'meta_title' => ['nullable', 'string', 'max:255'],
             'meta_description' => ['nullable', 'string', 'max:500'],
+            'email_on_publish' => ['sometimes', 'boolean'],
+            'mailing_lists' => ['nullable', 'array'],
+            'mailing_lists.*' => [Rule::enum(MailingList::class)],
         ];
     }
 }

--- a/app/Http/Requests/Staff/UpdatePostRequest.php
+++ b/app/Http/Requests/Staff/UpdatePostRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Staff;
 
 use App\Enums\Channel;
+use App\Enums\MailingList;
 use App\Enums\Role;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -27,6 +28,9 @@ class UpdatePostRequest extends FormRequest
             'channel' => ['required', Rule::enum(Channel::class)],
             'meta_title' => ['nullable', 'string', 'max:255'],
             'meta_description' => ['nullable', 'string', 'max:500'],
+            'email_on_publish' => ['sometimes', 'boolean'],
+            'mailing_lists' => ['nullable', 'array'],
+            'mailing_lists.*' => [Rule::enum(MailingList::class)],
         ];
     }
 }

--- a/app/Jobs/SendCampaignRecipientJob.php
+++ b/app/Jobs/SendCampaignRecipientJob.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\CampaignRecipientStatus;
+use App\Enums\CampaignStatus;
+use App\Enums\MailingList;
+use App\Mail\CampaignPostSummaryMail;
+use App\Models\Campaign;
+use App\Models\CampaignRecipient;
+use App\Services\Mailing\ConsentService;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\URL;
+use Throwable;
+
+class SendCampaignRecipientJob implements ShouldBeUnique, ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public int $uniqueFor = 3600;
+
+    public function __construct(public readonly int $recipientId) {}
+
+    public function uniqueId(): string
+    {
+        return 'campaign-recipient-'.$this->recipientId;
+    }
+
+    public function handle(ConsentService $consent): void
+    {
+        $recipient = CampaignRecipient::query()->with('campaign')->find($this->recipientId);
+
+        if (! $recipient || ! $recipient->campaign) {
+            return;
+        }
+
+        if ($recipient->status === CampaignRecipientStatus::Accepted) {
+            return;
+        }
+
+        $campaign = $recipient->campaign;
+        $recipient->increment('attempts');
+
+        if (! $campaign->is_test) {
+            if ($consent->isSuppressed($recipient->email)) {
+                $recipient->update([
+                    'status' => CampaignRecipientStatus::Skipped,
+                    'last_error' => 'suppressed',
+                ]);
+                $this->maybeComplete($campaign->id);
+
+                return;
+            }
+
+            $hasConsent = false;
+            foreach ($campaign->lists as $listValue) {
+                $list = MailingList::tryFrom($listValue);
+                if ($list && $consent->hasConfirmedConsent($recipient->email, $list)) {
+                    $hasConsent = true;
+                    break;
+                }
+            }
+
+            if (! $hasConsent) {
+                $recipient->update([
+                    'status' => CampaignRecipientStatus::Skipped,
+                    'last_error' => 'no_confirmed_consent',
+                ]);
+                $this->maybeComplete($campaign->id);
+
+                return;
+            }
+        }
+
+        $oneClickUnsubscribeUrl = $this->signedOneClickUnsubscribeUrl($recipient->email);
+        $unsubscribePageUrl = $this->signedUnsubscribePageUrl($recipient->email);
+        $preferencesUrl = $this->signedPreferencesUrl($recipient->email);
+
+        Mail::to($recipient->email)->send(new CampaignPostSummaryMail(
+            snapshot: $campaign->snapshot,
+            unsubscribeUrl: $unsubscribePageUrl,
+            preferencesUrl: $preferencesUrl,
+            listUnsubscribeUrl: $oneClickUnsubscribeUrl,
+            isTest: $campaign->is_test,
+        ));
+
+        $recipient->update([
+            'status' => CampaignRecipientStatus::Accepted,
+            'accepted_at' => now(),
+            'last_error' => null,
+        ]);
+
+        $this->maybeComplete($campaign->id);
+    }
+
+    public function failed(?Throwable $exception): void
+    {
+        $recipient = CampaignRecipient::query()->find($this->recipientId);
+        if (! $recipient) {
+            return;
+        }
+
+        $recipient->update([
+            'status' => CampaignRecipientStatus::Failed,
+            'failed_at' => now(),
+            'last_error' => $exception?->getMessage(),
+        ]);
+
+        $this->maybeComplete($recipient->campaign_id);
+    }
+
+    private function maybeComplete(int $campaignId): void
+    {
+        $pending = CampaignRecipient::query()
+            ->where('campaign_id', $campaignId)
+            ->where('status', CampaignRecipientStatus::Queued)
+            ->exists();
+
+        if (! $pending) {
+            Campaign::query()->whereKey($campaignId)->update([
+                'status' => CampaignStatus::Completed,
+                'completed_at' => now(),
+            ]);
+        }
+    }
+
+    private function signedOneClickUnsubscribeUrl(string $email): string
+    {
+        return URL::temporarySignedRoute(
+            'mailing.unsubscribe.one-click',
+            now()->addDays(30),
+            ['email' => $email],
+        );
+    }
+
+    private function signedUnsubscribePageUrl(string $email): string
+    {
+        return URL::temporarySignedRoute(
+            'mailing.unsubscribe',
+            now()->addDays(30),
+            ['email' => $email],
+        );
+    }
+
+    private function signedPreferencesUrl(string $email): string
+    {
+        return URL::temporarySignedRoute(
+            'mailing.preferences.signed',
+            now()->addDays(30),
+            ['email' => $email],
+        );
+    }
+}

--- a/app/Mail/CampaignPostSummaryMail.php
+++ b/app/Mail/CampaignPostSummaryMail.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Mail\Mailables\Headers;
+use Illuminate\Queue\SerializesModels;
+
+class CampaignPostSummaryMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * @param  array<string, mixed>  $snapshot
+     */
+    public function __construct(
+        public readonly array $snapshot,
+        public readonly string $unsubscribeUrl,
+        public readonly string $preferencesUrl,
+        public readonly string $listUnsubscribeUrl,
+        public readonly bool $isTest = false,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        $title = $this->snapshot['title'] ?? 'APES Newsroom';
+        $subject = $this->isTest
+            ? '[TEST] '.$title
+            : $title;
+
+        return new Envelope(subject: $subject);
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.campaign-post-summary',
+            with: [
+                'snapshot' => $this->snapshot,
+                'unsubscribeUrl' => $this->unsubscribeUrl,
+                'preferencesUrl' => $this->preferencesUrl,
+                'isTest' => $this->isTest,
+            ],
+        );
+    }
+
+    public function headers(): Headers
+    {
+        return new Headers(
+            text: [
+                'List-Unsubscribe' => '<'.$this->listUnsubscribeUrl.'>',
+                'List-Unsubscribe-Post' => 'List-Unsubscribe=One-Click',
+            ],
+        );
+    }
+}

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\CampaignStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable([
+    'post_id', 'created_by', 'lists', 'snapshot', 'status',
+    'is_test', 'test_recipient', 'queued_at', 'completed_at',
+])]
+class Campaign extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'lists' => 'array',
+            'snapshot' => 'array',
+            'status' => CampaignStatus::class,
+            'is_test' => 'boolean',
+            'queued_at' => 'datetime',
+            'completed_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Post, $this>
+     */
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /**
+     * @return HasMany<CampaignRecipient, $this>
+     */
+    public function recipients(): HasMany
+    {
+        return $this->hasMany(CampaignRecipient::class);
+    }
+}

--- a/app/Models/CampaignRecipient.php
+++ b/app/Models/CampaignRecipient.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\CampaignRecipientStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'campaign_id', 'email', 'status', 'attempts', 'idempotency_key',
+    'last_error', 'accepted_at', 'failed_at',
+])]
+class CampaignRecipient extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'status' => CampaignRecipientStatus::class,
+            'accepted_at' => 'datetime',
+            'failed_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Campaign, $this>
+     */
+    public function campaign(): BelongsTo
+    {
+        return $this->belongsTo(Campaign::class);
+    }
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ModerationStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+#[Fillable([
+    'post_id', 'user_id', 'body', 'moderation_status', 'moderation_notes',
+    'moderated_by', 'moderated_at', 'body_hash',
+])]
+class Comment extends Model
+{
+    use SoftDeletes;
+
+    protected function casts(): array
+    {
+        return [
+            'moderation_status' => ModerationStatus::class,
+            'moderated_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Post, $this>
+     */
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/ConsentEvent.php
+++ b/app/Models/ConsentEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ConsentAction;
+use App\Enums\MailingList;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'mailing_contact_id', 'email', 'list', 'action', 'source',
+    'wording_version', 'evidence', 'ip_address', 'user_agent',
+])]
+class ConsentEvent extends Model
+{
+    public $timestamps = false;
+
+    protected function casts(): array
+    {
+        return [
+            'list' => MailingList::class,
+            'action' => ConsentAction::class,
+            'evidence' => 'array',
+            'created_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<MailingContact, $this>
+     */
+    public function contact(): BelongsTo
+    {
+        return $this->belongsTo(MailingContact::class, 'mailing_contact_id');
+    }
+}

--- a/app/Models/MailingContact.php
+++ b/app/Models/MailingContact.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\MailingContactFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Notifications\Notifiable;
+
+#[Fillable(['email', 'user_id'])]
+class MailingContact extends Model
+{
+    /** @use HasFactory<MailingContactFactory> */
+    use HasFactory, Notifiable;
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return HasMany<MailingListSubscription, $this>
+     */
+    public function subscriptions(): HasMany
+    {
+        return $this->hasMany(MailingListSubscription::class);
+    }
+
+    /**
+     * Route mail notifications to the contact email.
+     */
+    public function routeNotificationForMail(): string
+    {
+        return $this->email;
+    }
+}

--- a/app/Models/MailingListSubscription.php
+++ b/app/Models/MailingListSubscription.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\MailingList;
+use App\Enums\SubscriptionStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'mailing_contact_id', 'list', 'status', 'confirm_token',
+    'confirmed_at', 'unsubscribed_at',
+])]
+class MailingListSubscription extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'list' => MailingList::class,
+            'status' => SubscriptionStatus::class,
+            'confirmed_at' => 'datetime',
+            'unsubscribed_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<MailingContact, $this>
+     */
+    public function contact(): BelongsTo
+    {
+        return $this->belongsTo(MailingContact::class, 'mailing_contact_id');
+    }
+
+    public function isConfirmed(): bool
+    {
+        return $this->status === SubscriptionStatus::Confirmed;
+    }
+}

--- a/app/Models/ModerationAudit.php
+++ b/app/Models/ModerationAudit.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+#[Fillable(['actor_id', 'subject_type', 'subject_id', 'action', 'payload', 'created_at'])]
+class ModerationAudit extends Model
+{
+    public $timestamps = false;
+
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'created_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_id');
+    }
+
+    public function subject(): MorphTo
+    {
+        return $this->morphTo(__FUNCTION__, 'subject_type', 'subject_id');
+    }
+}

--- a/app/Models/ModerationReport.php
+++ b/app/Models/ModerationReport.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+#[Fillable(['reporter_id', 'reportable_type', 'reportable_id', 'reason', 'status'])]
+class ModerationReport extends Model
+{
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function reporter(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reporter_id');
+    }
+
+    public function reportable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ModerationStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'user_id', 'display_name', 'bio', 'avatar_path', 'moderation_status',
+    'moderation_notes', 'moderated_by', 'moderated_at', 'public_opt_in',
+])]
+class Profile extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'moderation_status' => ModerationStatus::class,
+            'moderated_at' => 'datetime',
+            'public_opt_in' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function isPubliclyVisible(): bool
+    {
+        return $this->public_opt_in
+            && $this->moderation_status === ModerationStatus::Approved;
+    }
+
+    /**
+     * @return array{display_name: string, bio: string|null, avatar_url: string|null}|null
+     */
+    public function publicPayload(): ?array
+    {
+        if (! $this->isPubliclyVisible()) {
+            return null;
+        }
+
+        return [
+            'display_name' => $this->display_name ?? 'APES reader',
+            'bio' => $this->bio,
+            'avatar_url' => $this->avatar_path ? url('/storage/'.$this->avatar_path) : null,
+        ];
+    }
+}

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ReactionType;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['post_id', 'user_id', 'type'])]
+class Reaction extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'type' => ReactionType::class,
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Post, $this>
+     */
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Suppression.php
+++ b/app/Models/Suppression.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['email', 'reason', 'notes'])]
+class Suppression extends Model
+{
+    //
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -40,6 +41,14 @@ class User extends Authenticatable implements MustVerifyEmail
     public function magicLinkTokens(): HasMany
     {
         return $this->hasMany(MagicLinkToken::class);
+    }
+
+    /**
+     * @return HasOne<Profile, $this>
+     */
+    public function profile(): HasOne
+    {
+        return $this->hasOne(Profile::class);
     }
 
     /**

--- a/app/Notifications/ConfirmMailingListNotification.php
+++ b/app/Notifications/ConfirmMailingListNotification.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Enums\MailingList;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ConfirmMailingListNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly MailingList $list,
+        private readonly string $confirmUrl,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Confirm your '.$this->list->label().' subscription')
+            ->line('You asked to join the '.$this->list->label().' mailing list.')
+            ->line($this->list->purpose())
+            ->action('Confirm subscription', $this->confirmUrl)
+            ->line('If you did not request this, you can ignore this email.');
+    }
+}

--- a/app/Services/Engagement/CommentService.php
+++ b/app/Services/Engagement/CommentService.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace App\Services\Engagement;
+
+use App\Enums\ModerationStatus;
+use App\Models\Comment;
+use App\Models\ModerationAudit;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class CommentService
+{
+    public const MAX_LENGTH = 2000;
+
+    public function __construct(private readonly ProfileService $profiles) {}
+
+    public function create(User $user, Post $post, string $body): Comment
+    {
+        $this->assertCanInteract($user);
+
+        $clean = $this->sanitize($body);
+        $hash = hash('sha256', Str::lower($clean));
+
+        $duplicate = Comment::query()
+            ->where('user_id', $user->id)
+            ->where('post_id', $post->id)
+            ->where('body_hash', $hash)
+            ->where('created_at', '>=', now()->subMinutes(10))
+            ->exists();
+
+        if ($duplicate) {
+            throw ValidationException::withMessages([
+                'body' => 'Duplicate comment detected. Please wait before posting the same text again.',
+            ]);
+        }
+
+        $recentCount = Comment::query()
+            ->where('user_id', $user->id)
+            ->where('created_at', '>=', now()->subMinute())
+            ->count();
+
+        if ($recentCount >= 3) {
+            throw ValidationException::withMessages([
+                'body' => 'Comment rate limit exceeded. Please wait a moment.',
+            ]);
+        }
+
+        $comment = Comment::create([
+            'post_id' => $post->id,
+            'user_id' => $user->id,
+            'body' => $clean,
+            'body_hash' => $hash,
+            'moderation_status' => ModerationStatus::Pending,
+        ]);
+
+        $this->audit($user->id, $comment, 'comment_created');
+
+        return $comment;
+    }
+
+    public function update(User $user, Comment $comment, string $body): Comment
+    {
+        $this->assertCanInteract($user);
+
+        if ($comment->user_id !== $user->id) {
+            abort(403);
+        }
+
+        $clean = $this->sanitize($body);
+
+        $comment->update([
+            'body' => $clean,
+            'body_hash' => hash('sha256', Str::lower($clean)),
+            'moderation_status' => ModerationStatus::Pending,
+            'moderation_notes' => null,
+            'moderated_by' => null,
+            'moderated_at' => null,
+        ]);
+
+        $this->audit($user->id, $comment, 'comment_edited');
+
+        return $comment->fresh();
+    }
+
+    public function moderate(Comment $comment, User $moderator, ModerationStatus $status, ?string $notes = null): Comment
+    {
+        $comment->update([
+            'moderation_status' => $status,
+            'moderation_notes' => $notes,
+            'moderated_by' => $moderator->id,
+            'moderated_at' => now(),
+        ]);
+
+        $this->audit($moderator->id, $comment, 'comment_moderated', [
+            'status' => $status->value,
+            'notes' => $notes,
+        ]);
+
+        return $comment->fresh();
+    }
+
+    /**
+     * @return list<array{id: int, body: string, created_at: string|null, author: array{display_name: string, avatar_url: string|null}|null}>
+     */
+    public function approvedPayloadForPost(Post $post): array
+    {
+        return Comment::query()
+            ->where('post_id', $post->id)
+            ->where('moderation_status', ModerationStatus::Approved)
+            ->with(['user.profile'])
+            ->latest()
+            ->get()
+            ->map(function (Comment $comment) {
+                $profile = $comment->user->profile;
+                $public = $profile?->publicPayload();
+
+                return [
+                    'id' => $comment->id,
+                    'body' => $comment->body,
+                    'created_at' => $comment->created_at?->toIso8601String(),
+                    'author' => $public ? [
+                        'display_name' => $public['display_name'],
+                        'avatar_url' => $public['avatar_url'],
+                    ] : [
+                        'display_name' => 'APES reader',
+                        'avatar_url' => null,
+                    ],
+                ];
+            })
+            ->all();
+    }
+
+    public function assertCanInteract(User $user): void
+    {
+        if (! $user->hasVerifiedEmail()) {
+            abort(403, 'Verified account required.');
+        }
+
+        $profile = $this->profiles->forUser($user);
+        if ($profile->moderation_status === ModerationStatus::Suspended) {
+            abort(403, 'Account suspended from engagement.');
+        }
+    }
+
+    private function sanitize(string $body): string
+    {
+        $clean = trim(strip_tags($body));
+        $clean = preg_replace('/https?:\/\/\S+/i', '', $clean) ?? $clean;
+        $clean = preg_replace('/\s+/', ' ', $clean) ?? $clean;
+        $clean = trim($clean);
+
+        if ($clean === '' || mb_strlen($clean) > self::MAX_LENGTH) {
+            throw ValidationException::withMessages([
+                'body' => 'Comment must be between 1 and '.self::MAX_LENGTH.' characters without links.',
+            ]);
+        }
+
+        return $clean;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function audit(?int $actorId, Comment $comment, string $action, array $payload = []): void
+    {
+        ModerationAudit::create([
+            'actor_id' => $actorId,
+            'subject_type' => Comment::class,
+            'subject_id' => $comment->id,
+            'action' => $action,
+            'payload' => $payload === [] ? null : $payload,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/app/Services/Engagement/ProfileService.php
+++ b/app/Services/Engagement/ProfileService.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Services\Engagement;
+
+use App\Enums\ModerationStatus;
+use App\Models\ModerationAudit;
+use App\Models\Profile;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ProfileService
+{
+    public function forUser(User $user): Profile
+    {
+        return Profile::query()->firstOrCreate(
+            ['user_id' => $user->id],
+            [
+                'moderation_status' => ModerationStatus::Private,
+                'public_opt_in' => false,
+                'display_name' => $user->name,
+            ],
+        );
+    }
+
+    /**
+     * @param  array{display_name?: string|null, bio?: string|null, public_opt_in?: bool}  $data
+     */
+    public function update(User $user, array $data, ?UploadedFile $avatar = null): Profile
+    {
+        $profile = $this->forUser($user);
+        $materialChange = false;
+
+        foreach (['display_name', 'bio'] as $field) {
+            if (array_key_exists($field, $data) && $data[$field] !== $profile->{$field}) {
+                $materialChange = true;
+                $profile->{$field} = $data[$field];
+            }
+        }
+
+        if (array_key_exists('public_opt_in', $data)) {
+            $optIn = (bool) $data['public_opt_in'];
+            if ($optIn !== $profile->public_opt_in) {
+                $materialChange = true;
+                $profile->public_opt_in = $optIn;
+            }
+        }
+
+        if ($avatar) {
+            $path = $this->storeAvatar($avatar, $user->id);
+            if ($profile->avatar_path) {
+                Storage::disk('public')->delete($profile->avatar_path);
+            }
+            $profile->avatar_path = $path;
+            $materialChange = true;
+        }
+
+        if ($materialChange && $profile->public_opt_in) {
+            $profile->moderation_status = ModerationStatus::Pending;
+            $profile->moderation_notes = null;
+            $profile->moderated_by = null;
+            $profile->moderated_at = null;
+        } elseif (! $profile->public_opt_in) {
+            $profile->moderation_status = ModerationStatus::Private;
+        }
+
+        $profile->save();
+
+        $this->audit($user->id, $profile, 'profile_updated', [
+            'public_opt_in' => $profile->public_opt_in,
+            'status' => $profile->moderation_status->value,
+        ]);
+
+        return $profile->fresh();
+    }
+
+    public function moderate(Profile $profile, User $moderator, ModerationStatus $status, ?string $notes = null): Profile
+    {
+        $profile->update([
+            'moderation_status' => $status,
+            'moderation_notes' => $notes,
+            'moderated_by' => $moderator->id,
+            'moderated_at' => now(),
+        ]);
+
+        $this->audit($moderator->id, $profile, 'profile_moderated', [
+            'status' => $status->value,
+            'notes' => $notes,
+        ]);
+
+        return $profile->fresh();
+    }
+
+    private function storeAvatar(UploadedFile $avatar, int $userId): string
+    {
+        $relative = 'avatars/'.$userId.'/'.Str::uuid().'.jpg';
+
+        if (function_exists('imagecreatefromstring')) {
+            $image = @imagecreatefromstring($avatar->get());
+            if ($image === false) {
+                throw new \InvalidArgumentException('Invalid image upload.');
+            }
+
+            $width = imagesx($image);
+            $height = imagesy($image);
+            $size = min($width, $height, 512);
+            $dst = imagecreatetruecolor($size, $size);
+            imagecopyresampled(
+                $dst,
+                $image,
+                0,
+                0,
+                (int) (($width - min($width, $height)) / 2),
+                (int) (($height - min($width, $height)) / 2),
+                $size,
+                $size,
+                min($width, $height),
+                min($width, $height),
+            );
+
+            $absolute = Storage::disk('public')->path($relative);
+            if (! is_dir(dirname($absolute))) {
+                mkdir(dirname($absolute), 0755, true);
+            }
+            imagejpeg($dst, $absolute, 85);
+            imagedestroy($image);
+            imagedestroy($dst);
+
+            return $relative;
+        }
+
+        return $avatar->storeAs(
+            'avatars/'.$userId,
+            Str::uuid().'.'.$avatar->getClientOriginalExtension(),
+            'public',
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function audit(?int $actorId, Profile $profile, string $action, array $payload = []): void
+    {
+        ModerationAudit::create([
+            'actor_id' => $actorId,
+            'subject_type' => Profile::class,
+            'subject_id' => $profile->id,
+            'action' => $action,
+            'payload' => $payload,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/app/Services/Engagement/ReactionService.php
+++ b/app/Services/Engagement/ReactionService.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services\Engagement;
+
+use App\Enums\ReactionType;
+use App\Models\Post;
+use App\Models\Reaction;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class ReactionService
+{
+    public function __construct(private readonly CommentService $comments) {}
+
+    /**
+     * Toggle a reaction. Returns whether the reaction is now active.
+     */
+    public function toggle(User $user, Post $post, ReactionType $type): bool
+    {
+        $this->comments->assertCanInteract($user);
+
+        return DB::transaction(function () use ($user, $post, $type) {
+            $existing = Reaction::query()
+                ->where('user_id', $user->id)
+                ->where('post_id', $post->id)
+                ->where('type', $type->value)
+                ->lockForUpdate()
+                ->first();
+
+            if ($existing) {
+                $existing->delete();
+
+                return false;
+            }
+
+            Reaction::query()->firstOrCreate([
+                'user_id' => $user->id,
+                'post_id' => $post->id,
+                'type' => $type->value,
+            ]);
+
+            return true;
+        });
+    }
+
+    /**
+     * @return array{helpful: int, support: int, thank_you: int, mine: list<string>}
+     */
+    public function countsForPost(Post $post, ?User $viewer = null): array
+    {
+        $counts = [
+            ReactionType::Helpful->value => 0,
+            ReactionType::Support->value => 0,
+            ReactionType::ThankYou->value => 0,
+        ];
+
+        $rows = Reaction::query()
+            ->where('post_id', $post->id)
+            ->selectRaw('type, count(*) as aggregate')
+            ->groupBy('type')
+            ->pluck('aggregate', 'type');
+
+        foreach ($rows as $type => $count) {
+            if (array_key_exists($type, $counts)) {
+                $counts[$type] = (int) $count;
+            }
+        }
+
+        $mine = [];
+        if ($viewer) {
+            $mine = Reaction::query()
+                ->where('post_id', $post->id)
+                ->where('user_id', $viewer->id)
+                ->pluck('type')
+                ->map(fn ($t) => $t instanceof ReactionType ? $t->value : (string) $t)
+                ->all();
+        }
+
+        return [
+            'helpful' => $counts[ReactionType::Helpful->value],
+            'support' => $counts[ReactionType::Support->value],
+            'thank_you' => $counts[ReactionType::ThankYou->value],
+            'mine' => $mine,
+        ];
+    }
+}

--- a/app/Services/Mailing/CampaignService.php
+++ b/app/Services/Mailing/CampaignService.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Services\Mailing;
+
+use App\Enums\CampaignRecipientStatus;
+use App\Enums\CampaignStatus;
+use App\Enums\MailingList;
+use App\Jobs\SendCampaignRecipientJob;
+use App\Models\Campaign;
+use App\Models\CampaignRecipient;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class CampaignService
+{
+    public function __construct(private readonly ConsentService $consent) {}
+
+    /**
+     * Create an immutable live campaign from a published post when email_on_publish is set.
+     * Idempotent: returns existing live campaign if one already exists for the post.
+     */
+    public function createFromPublishedPost(Post $post, User $actor): ?Campaign
+    {
+        if (! $post->email_on_publish) {
+            return null;
+        }
+
+        $lists = $this->normalizeListValues($post->mailing_lists ?? []);
+        if ($lists === []) {
+            return null;
+        }
+
+        $existing = Campaign::query()
+            ->where('post_id', $post->id)
+            ->where('is_test', false)
+            ->first();
+
+        if ($existing) {
+            return $existing;
+        }
+
+        return DB::transaction(function () use ($post, $actor, $lists) {
+            $campaign = Campaign::create([
+                'post_id' => $post->id,
+                'created_by' => $actor->id,
+                'lists' => $lists,
+                'snapshot' => $this->buildSnapshot($post),
+                'status' => CampaignStatus::Queued,
+                'is_test' => false,
+                'queued_at' => now(),
+            ]);
+
+            $emails = $this->consent->confirmedEmailsForLists($lists);
+
+            foreach ($emails as $email) {
+                $this->createRecipient($campaign, $email);
+            }
+
+            $this->dispatchRecipients($campaign);
+
+            return $campaign->fresh(['recipients']);
+        });
+    }
+
+    public function createTestSend(Post $post, User $actor, string $recipientEmail): Campaign
+    {
+        $lists = $this->normalizeListValues($post->mailing_lists ?? []);
+        if ($lists === []) {
+            $lists = [MailingList::ApesCic->value];
+        }
+
+        $email = Str::lower(trim($recipientEmail));
+
+        return DB::transaction(function () use ($post, $actor, $lists, $email) {
+            $campaign = Campaign::create([
+                'post_id' => $post->id,
+                'created_by' => $actor->id,
+                'lists' => $lists,
+                'snapshot' => $this->buildSnapshot($post),
+                'status' => CampaignStatus::Queued,
+                'is_test' => true,
+                'test_recipient' => $email,
+                'queued_at' => now(),
+            ]);
+
+            $recipient = $this->createRecipient($campaign, $email);
+            SendCampaignRecipientJob::dispatch($recipient->id)->onQueue('mail-test');
+
+            return $campaign->fresh(['recipients']);
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildSnapshot(Post $post): array
+    {
+        $post->loadMissing('author');
+
+        return [
+            'title' => $post->title,
+            'excerpt' => $post->excerpt,
+            'hero_image' => $post->hero_image,
+            'hero_image_alt' => $post->hero_image_alt,
+            'author' => $post->author->name,
+            'channel' => $post->channel->value,
+            'channel_label' => $post->channel->label(),
+            'published_at' => $post->published_at?->toIso8601String(),
+            'read_more_url' => url('/articles/'.$post->slug),
+            'slug' => $post->slug,
+        ];
+    }
+
+    public function previewPayload(Post $post): array
+    {
+        return $this->buildSnapshot($post);
+    }
+
+    private function createRecipient(Campaign $campaign, string $email): CampaignRecipient
+    {
+        return CampaignRecipient::create([
+            'campaign_id' => $campaign->id,
+            'email' => $email,
+            'status' => CampaignRecipientStatus::Queued,
+            'idempotency_key' => hash('sha256', $campaign->id.'|'.$email),
+            'attempts' => 0,
+        ]);
+    }
+
+    private function dispatchRecipients(Campaign $campaign): void
+    {
+        $delaySeconds = 0;
+        $perMinute = (int) config('mailing.throttle_per_minute', 60);
+        $interval = $perMinute > 0 ? (int) ceil(60 / $perMinute) : 1;
+
+        $campaign->recipients()
+            ->where('status', CampaignRecipientStatus::Queued)
+            ->orderBy('id')
+            ->each(function (CampaignRecipient $recipient) use (&$delaySeconds, $interval) {
+                SendCampaignRecipientJob::dispatch($recipient->id)
+                    ->delay(now()->addSeconds($delaySeconds));
+                $delaySeconds += $interval;
+            });
+
+        $campaign->update(['status' => CampaignStatus::Sending]);
+    }
+
+    /**
+     * @param  list<string>  $lists
+     * @return list<string>
+     */
+    private function normalizeListValues(array $lists): array
+    {
+        $out = [];
+        foreach ($lists as $list) {
+            $enum = MailingList::tryFrom((string) $list);
+            if ($enum) {
+                $out[$enum->value] = $enum->value;
+            }
+        }
+
+        return array_values($out);
+    }
+}

--- a/app/Services/Mailing/ConsentService.php
+++ b/app/Services/Mailing/ConsentService.php
@@ -1,0 +1,398 @@
+<?php
+
+namespace App\Services\Mailing;
+
+use App\Enums\ConsentAction;
+use App\Enums\MailingList;
+use App\Enums\SubscriptionStatus;
+use App\Models\ConsentEvent;
+use App\Models\MailingContact;
+use App\Models\MailingListSubscription;
+use App\Models\Suppression;
+use App\Models\User;
+use App\Notifications\ConfirmMailingListNotification;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class ConsentService
+{
+    public const WORDING_VERSION = 'v1';
+
+    /**
+     * @param  list<string>  $lists
+     */
+    public function signup(
+        string $email,
+        array $lists,
+        string $source,
+        ?User $user = null,
+        ?string $ip = null,
+        ?string $userAgent = null,
+    ): MailingContact {
+        $email = Str::lower(trim($email));
+        $lists = $this->normalizeLists($lists);
+
+        if ($lists === []) {
+            throw new \InvalidArgumentException('At least one mailing list must be selected.');
+        }
+
+        return DB::transaction(function () use ($email, $lists, $source, $user, $ip, $userAgent) {
+            $contact = MailingContact::query()->firstOrCreate(
+                ['email' => $email],
+                ['user_id' => $user?->id],
+            );
+
+            if ($user && $contact->user_id === null) {
+                $contact->update(['user_id' => $user->id]);
+            }
+
+            foreach ($lists as $list) {
+                $subscription = MailingListSubscription::query()->firstOrNew([
+                    'mailing_contact_id' => $contact->id,
+                    'list' => $list->value,
+                ]);
+
+                if ($subscription->status === SubscriptionStatus::Confirmed) {
+                    continue;
+                }
+
+                $token = Str::random(64);
+                $subscription->fill([
+                    'status' => SubscriptionStatus::Pending,
+                    'confirm_token' => $token,
+                    'confirmed_at' => null,
+                    'unsubscribed_at' => null,
+                ]);
+                $subscription->save();
+
+                $this->recordEvent(
+                    $contact,
+                    $list,
+                    ConsentAction::SignupRequested,
+                    $source,
+                    ['confirm_token_issued' => true],
+                    $ip,
+                    $userAgent,
+                );
+
+                $contact->notify(new ConfirmMailingListNotification(
+                    $list,
+                    $this->confirmUrl($token),
+                ));
+            }
+
+            return $contact->fresh(['subscriptions']);
+        });
+    }
+
+    public function confirm(string $token, ?string $ip = null, ?string $userAgent = null): MailingListSubscription
+    {
+        $subscription = MailingListSubscription::query()
+            ->where('confirm_token', $token)
+            ->where('status', SubscriptionStatus::Pending)
+            ->firstOrFail();
+
+        $subscription->update([
+            'status' => SubscriptionStatus::Confirmed,
+            'confirm_token' => null,
+            'confirmed_at' => now(),
+            'unsubscribed_at' => null,
+        ]);
+
+        $this->recordEvent(
+            $subscription->contact,
+            $subscription->list,
+            ConsentAction::Confirmed,
+            'double_opt_in',
+            ['verified' => true],
+            $ip,
+            $userAgent,
+        );
+
+        return $subscription->fresh(['contact']);
+    }
+
+    public function unsubscribe(
+        string $email,
+        ?MailingList $list = null,
+        string $source = 'unsubscribe_link',
+        ?string $ip = null,
+        ?string $userAgent = null,
+    ): void {
+        $email = Str::lower(trim($email));
+        $contact = MailingContact::query()->where('email', $email)->first();
+
+        if (! $contact) {
+            Suppression::query()->firstOrCreate(
+                ['email' => $email],
+                ['reason' => 'unsubscribe_without_contact'],
+            );
+
+            return;
+        }
+
+        $query = $contact->subscriptions();
+        if ($list) {
+            $query->where('list', $list->value);
+        }
+
+        /** @var Collection<int, MailingListSubscription> $subscriptions */
+        $subscriptions = $query->get();
+
+        foreach ($subscriptions as $subscription) {
+            if ($subscription->status === SubscriptionStatus::Unsubscribed) {
+                continue;
+            }
+
+            $subscription->update([
+                'status' => SubscriptionStatus::Unsubscribed,
+                'confirm_token' => null,
+                'unsubscribed_at' => now(),
+            ]);
+
+            $this->recordEvent(
+                $contact,
+                $subscription->list,
+                ConsentAction::Unsubscribed,
+                $source,
+                [],
+                $ip,
+                $userAgent,
+            );
+        }
+
+        if ($list === null) {
+            Suppression::query()->firstOrCreate(
+                ['email' => $email],
+                ['reason' => 'unsubscribe_all'],
+            );
+
+            $this->recordEvent(
+                $contact,
+                null,
+                ConsentAction::Suppressed,
+                $source,
+                ['reason' => 'unsubscribe_all'],
+                $ip,
+                $userAgent,
+            );
+        }
+    }
+
+    /**
+     * Sync account preference centre choices (checked = request DOI or keep confirmed).
+     *
+     * @param  list<string>  $selectedLists
+     */
+    public function syncAccountPreferences(
+        User $user,
+        array $selectedLists,
+        ?string $ip = null,
+        ?string $userAgent = null,
+    ): void {
+        $email = Str::lower($user->email);
+        $selected = collect($this->normalizeLists($selectedLists))->map->value->all();
+
+        $contact = MailingContact::query()->firstOrCreate(
+            ['email' => $email],
+            ['user_id' => $user->id],
+        );
+
+        if ($contact->user_id !== $user->id) {
+            $contact->update(['user_id' => $user->id]);
+        }
+
+        foreach (MailingList::cases() as $list) {
+            $subscription = MailingListSubscription::query()->firstOrNew([
+                'mailing_contact_id' => $contact->id,
+                'list' => $list->value,
+            ]);
+
+            $wants = in_array($list->value, $selected, true);
+
+            if ($wants) {
+                if ($subscription->exists && $subscription->status === SubscriptionStatus::Confirmed) {
+                    continue;
+                }
+
+                if ($subscription->exists && $subscription->status === SubscriptionStatus::Pending) {
+                    continue;
+                }
+
+                $token = Str::random(64);
+                $subscription->fill([
+                    'status' => SubscriptionStatus::Pending,
+                    'confirm_token' => $token,
+                    'confirmed_at' => null,
+                    'unsubscribed_at' => null,
+                ]);
+                $subscription->save();
+
+                $this->recordEvent(
+                    $contact,
+                    $list,
+                    ConsentAction::SignupRequested,
+                    'account_preferences',
+                    ['confirm_token_issued' => true],
+                    $ip,
+                    $userAgent,
+                );
+
+                $contact->notify(new ConfirmMailingListNotification(
+                    $list,
+                    $this->confirmUrl($token),
+                ));
+            } elseif ($subscription->exists && $subscription->status !== SubscriptionStatus::Unsubscribed) {
+                $subscription->update([
+                    'status' => SubscriptionStatus::Unsubscribed,
+                    'confirm_token' => null,
+                    'unsubscribed_at' => now(),
+                ]);
+
+                $this->recordEvent(
+                    $contact,
+                    $list,
+                    ConsentAction::Unsubscribed,
+                    'account_preferences',
+                    [],
+                    $ip,
+                    $userAgent,
+                );
+            }
+        }
+    }
+
+    public function isSuppressed(string $email): bool
+    {
+        return Suppression::query()->where('email', Str::lower(trim($email)))->exists();
+    }
+
+    public function hasConfirmedConsent(string $email, MailingList $list): bool
+    {
+        if ($this->isSuppressed($email)) {
+            return false;
+        }
+
+        $contact = MailingContact::query()->where('email', Str::lower(trim($email)))->first();
+
+        if (! $contact) {
+            return false;
+        }
+
+        return $contact->subscriptions()
+            ->where('list', $list->value)
+            ->where('status', SubscriptionStatus::Confirmed)
+            ->exists();
+    }
+
+    /**
+     * Confirmed emails for any of the given lists, de-duplicated.
+     *
+     * @param  list<string|MailingList>  $lists
+     * @return list<string>
+     */
+    public function confirmedEmailsForLists(array $lists): array
+    {
+        $normalized = $this->normalizeLists($lists);
+        if ($normalized === []) {
+            return [];
+        }
+
+        $listValues = array_map(fn (MailingList $l) => $l->value, $normalized);
+
+        $emails = MailingListSubscription::query()
+            ->whereIn('list', $listValues)
+            ->where('status', SubscriptionStatus::Confirmed)
+            ->with('contact')
+            ->get()
+            ->pluck('contact.email')
+            ->filter()
+            ->map(fn (string $email) => Str::lower($email))
+            ->unique()
+            ->values();
+
+        $suppressed = Suppression::query()->pluck('email')->map(fn (string $e) => Str::lower($e))->all();
+
+        return $emails->reject(fn (string $email) => in_array($email, $suppressed, true))->values()->all();
+    }
+
+    /**
+     * @return array<string, array{list: string, label: string, status: string|null, purpose: string}>
+     */
+    public function preferenceStateForEmail(string $email): array
+    {
+        $contact = MailingContact::query()->where('email', Str::lower(trim($email)))->first();
+        $subscriptions = $contact
+            ? $contact->subscriptions->keyBy(fn (MailingListSubscription $s) => $s->list->value)
+            : collect();
+
+        $state = [];
+        foreach (MailingList::cases() as $list) {
+            /** @var MailingListSubscription|null $sub */
+            $sub = $subscriptions->get($list->value);
+            $state[$list->value] = [
+                'list' => $list->value,
+                'label' => $list->label(),
+                'purpose' => $list->purpose(),
+                'status' => $sub?->status->value,
+            ];
+        }
+
+        return $state;
+    }
+
+    private function confirmUrl(string $token): string
+    {
+        return url('/mailing/confirm/'.$token);
+    }
+
+    /**
+     * @param  list<string|MailingList>  $lists
+     * @return list<MailingList>
+     */
+    private function normalizeLists(array $lists): array
+    {
+        $out = [];
+        foreach ($lists as $list) {
+            if ($list instanceof MailingList) {
+                $out[$list->value] = $list;
+
+                continue;
+            }
+
+            $enum = MailingList::tryFrom((string) $list);
+            if ($enum) {
+                $out[$enum->value] = $enum;
+            }
+        }
+
+        return array_values($out);
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function recordEvent(
+        ?MailingContact $contact,
+        ?MailingList $list,
+        ConsentAction $action,
+        string $source,
+        array $evidence = [],
+        ?string $ip = null,
+        ?string $userAgent = null,
+    ): void {
+        ConsentEvent::create([
+            'mailing_contact_id' => $contact?->id,
+            'email' => $contact?->email ?? '',
+            'list' => $list?->value,
+            'action' => $action,
+            'source' => $source,
+            'wording_version' => self::WORDING_VERSION,
+            'evidence' => $evidence === [] ? null : $evidence,
+            'ip_address' => $ip,
+            'user_agent' => $userAgent,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/config/mailing.php
+++ b/config/mailing.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Campaign send throttle
+    |--------------------------------------------------------------------------
+    |
+    | Maximum live campaign recipients accepted by SMTP per minute.
+    | Measured capacity testing on beta may raise this later.
+    |
+    */
+    'throttle_per_minute' => (int) env('MAILING_THROTTLE_PER_MINUTE', 60),
+
+    'contact_address' => env('MAILING_CONTACT_ADDRESS', 'newsroom@apesnews.org.uk'),
+];

--- a/database/factories/MailingContactFactory.php
+++ b/database/factories/MailingContactFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\MailingContact;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<MailingContact>
+ */
+class MailingContactFactory extends Factory
+{
+    protected $model = MailingContact::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'email' => fake()->unique()->safeEmail(),
+            'user_id' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_08_06_140000_create_mailing_tables.php
+++ b/database/migrations/2026_08_06_140000_create_mailing_tables.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('mailing_contacts', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->unique();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('mailing_list_subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('mailing_contact_id')->constrained()->cascadeOnDelete();
+            $table->string('list');
+            $table->string('status')->default('pending')->index();
+            $table->string('confirm_token', 64)->nullable()->unique();
+            $table->timestamp('confirmed_at')->nullable();
+            $table->timestamp('unsubscribed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['mailing_contact_id', 'list']);
+        });
+
+        Schema::create('consent_events', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('mailing_contact_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('email')->index();
+            $table->string('list')->nullable();
+            $table->string('action');
+            $table->string('source');
+            $table->string('wording_version')->default('v1');
+            $table->json('evidence')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+
+        Schema::create('suppressions', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->unique();
+            $table->string('reason');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('campaigns', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('created_by')->constrained('users')->cascadeOnDelete();
+            $table->json('lists');
+            $table->json('snapshot');
+            $table->string('status')->default('queued')->index();
+            $table->boolean('is_test')->default(false);
+            $table->string('test_recipient')->nullable();
+            $table->timestamp('queued_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['post_id', 'is_test']);
+        });
+
+        Schema::create('campaign_recipients', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('campaign_id')->constrained()->cascadeOnDelete();
+            $table->string('email');
+            $table->string('status')->default('queued')->index();
+            $table->unsignedTinyInteger('attempts')->default(0);
+            $table->string('idempotency_key')->unique();
+            $table->text('last_error')->nullable();
+            $table->timestamp('accepted_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['campaign_id', 'email']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('campaign_recipients');
+        Schema::dropIfExists('campaigns');
+        Schema::dropIfExists('suppressions');
+        Schema::dropIfExists('consent_events');
+        Schema::dropIfExists('mailing_list_subscriptions');
+        Schema::dropIfExists('mailing_contacts');
+    }
+};

--- a/database/migrations/2026_08_06_150000_create_engagement_tables.php
+++ b/database/migrations/2026_08_06_150000_create_engagement_tables.php
@@ -1,0 +1,84 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('display_name')->nullable();
+            $table->text('bio')->nullable();
+            $table->string('avatar_path')->nullable();
+            $table->string('moderation_status')->default('private')->index();
+            $table->text('moderation_notes')->nullable();
+            $table->foreignId('moderated_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('moderated_at')->nullable();
+            $table->boolean('public_opt_in')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->text('body');
+            $table->string('moderation_status')->default('pending')->index();
+            $table->text('moderation_notes')->nullable();
+            $table->foreignId('moderated_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('moderated_at')->nullable();
+            $table->string('body_hash', 64)->index();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['post_id', 'moderation_status']);
+        });
+
+        Schema::create('reactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'post_id', 'type']);
+        });
+
+        Schema::create('moderation_reports', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('reporter_id')->constrained('users')->cascadeOnDelete();
+            $table->string('reportable_type');
+            $table->unsignedBigInteger('reportable_id');
+            $table->text('reason');
+            $table->string('status')->default('open')->index();
+            $table->timestamps();
+
+            $table->index(['reportable_type', 'reportable_id']);
+        });
+
+        Schema::create('moderation_audits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('actor_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('subject_type');
+            $table->unsignedBigInteger('subject_id');
+            $table->string('action');
+            $table->json('payload')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['subject_type', 'subject_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('moderation_audits');
+        Schema::dropIfExists('moderation_reports');
+        Schema::dropIfExists('reactions');
+        Schema::dropIfExists('comments');
+        Schema::dropIfExists('profiles');
+    }
+};

--- a/docs/epic-1-build-plan.md
+++ b/docs/epic-1-build-plan.md
@@ -1,6 +1,6 @@
 # Epic #1 build plan: APES Newsroom (replacing Ghost)
 
-Source: [Issue #1](https://github.com/APESCIC/APES-Newsroom/issues/1) and its ten sub-issues (#2–#11). Repo is currently empty (README only), so this plan starts from zero.
+Source: [Issue #1](https://github.com/APESCIC/APES-Newsroom/issues/1) and its ten sub-issues (#2–#11). Phases 0–3 are implemented in code on the main delivery branch; #2–#6 still have residual acceptance work (Editor.js UI, discovery polish) tracked on those issues.
 
 ## What we're building
 
@@ -95,4 +95,4 @@ Who is doing the #2 design work — is that Bambie/a designer producing wirefram
 
 ## Suggested next step
 
-Start **#3 (Laravel foundation)** — it's the only issue with no upstream dependency and everything else needs it to exist before code can run. #2 can proceed in parallel on the design side if that's being handled separately.
+**Phase 3 (#7 mailing, #8 engagement) is implemented.** Next build focus is **#9 Ghost migration** once mailing/consent and content schemas are accepted as stable enough to import into. Continue polishing #5/#6 residuals (Editor.js UI, archives) in parallel. #10 governance artifacts and #11 cutover remain separately gated.

--- a/resources/js/Pages/Account/Profile.tsx
+++ b/resources/js/Pages/Account/Profile.tsx
@@ -61,6 +61,20 @@ export default function Profile({ user, status }: { user: ProfileUser; status?: 
                 </form>
 
                 <section className="flex flex-col gap-3 border-t border-neutral-200 pt-6">
+                    <h2 className="text-lg font-medium">Public profile</h2>
+                    <Link href="/account/public-profile" className="text-sm underline">
+                        Edit public profile
+                    </Link>
+                </section>
+
+                <section className="flex flex-col gap-3 border-t border-neutral-200 pt-6">
+                    <h2 className="text-lg font-medium">Mailing lists</h2>
+                    <Link href="/account/mailing" className="text-sm underline">
+                        Manage mailing preferences
+                    </Link>
+                </section>
+
+                <section className="flex flex-col gap-3 border-t border-neutral-200 pt-6">
                     <h2 className="text-lg font-medium">Your data</h2>
                     <Link href="/account/export" className="text-sm underline">
                         Download account data (JSON)

--- a/resources/js/Pages/Account/PublicProfile.tsx
+++ b/resources/js/Pages/Account/PublicProfile.tsx
@@ -1,0 +1,95 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+type ProfileData = {
+    display_name: string | null;
+    bio: string | null;
+    avatar_url: string | null;
+    public_opt_in: boolean;
+    moderation_status: string;
+    moderation_notes: string | null;
+};
+
+export default function PublicProfile({ profile, status }: { profile: ProfileData; status?: string }) {
+    const { data, setData, post, processing, errors } = useForm({
+        display_name: profile.display_name ?? '',
+        bio: profile.bio ?? '',
+        public_opt_in: profile.public_opt_in,
+        avatar: null as File | null,
+    });
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        post('/account/public-profile', { forceFormData: true });
+    };
+
+    return (
+        <>
+            <Head title="Public profile" />
+            <main className="mx-auto max-w-lg px-6 py-12">
+                <Link href="/account" className="text-sm underline">
+                    ← Account
+                </Link>
+                <h1 className="mt-4 text-2xl font-semibold">Public profile</h1>
+                <p className="mt-2 text-sm text-neutral-600">
+                    Profiles are private by default. Opting in submits your profile for moderation before it appears
+                    publicly.
+                </p>
+                <p className="mt-2 text-sm">
+                    Status: <strong>{profile.moderation_status}</strong>
+                </p>
+                {profile.moderation_notes && (
+                    <p className="mt-1 text-sm text-red-700">Moderator note: {profile.moderation_notes}</p>
+                )}
+                {status === 'profile-submitted' && (
+                    <p className="mt-2 text-sm text-green-700">Profile saved. Public changes await moderation.</p>
+                )}
+
+                <form onSubmit={submit} className="mt-8 flex flex-col gap-4">
+                    <div>
+                        <label htmlFor="display_name">Display name</label>
+                        <input
+                            id="display_name"
+                            value={data.display_name}
+                            onChange={(e) => setData('display_name', e.target.value)}
+                            className="w-full rounded border px-3 py-2"
+                        />
+                        {errors.display_name && <p className="text-sm text-red-600">{errors.display_name}</p>}
+                    </div>
+                    <div>
+                        <label htmlFor="bio">Bio</label>
+                        <textarea
+                            id="bio"
+                            value={data.bio}
+                            onChange={(e) => setData('bio', e.target.value)}
+                            rows={4}
+                            maxLength={500}
+                            className="w-full rounded border px-3 py-2"
+                        />
+                    </div>
+                    <div>
+                        <label htmlFor="avatar">Avatar</label>
+                        <input
+                            id="avatar"
+                            type="file"
+                            accept="image/jpeg,image/png,image/webp"
+                            onChange={(e) => setData('avatar', e.target.files?.[0] ?? null)}
+                        />
+                        {errors.avatar && <p className="text-sm text-red-600">{errors.avatar}</p>}
+                    </div>
+                    <label className="flex gap-2 text-sm">
+                        <input
+                            type="checkbox"
+                            checked={data.public_opt_in}
+                            onChange={(e) => setData('public_opt_in', e.target.checked)}
+                        />
+                        Make my profile public after approval
+                    </label>
+                    <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
+                        Save profile
+                    </button>
+                </form>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Admin/Moderation/Index.tsx
+++ b/resources/js/Pages/Admin/Moderation/Index.tsx
@@ -1,0 +1,104 @@
+import { Head, router } from '@inertiajs/react';
+
+type PendingProfile = {
+    id: number;
+    display_name: string | null;
+    bio: string | null;
+    user_name: string;
+    updated_at: string | null;
+};
+
+type PendingComment = {
+    id: number;
+    body: string;
+    user_name: string;
+    post_title: string;
+    post_slug: string;
+    created_at: string | null;
+};
+
+export default function ModerationIndex({
+    profiles,
+    comments,
+}: {
+    profiles: PendingProfile[];
+    comments: PendingComment[];
+}) {
+    const moderateProfile = (id: number, status: string) => {
+        router.post(`/admin/moderation/profiles/${id}`, { status });
+    };
+
+    const moderateComment = (id: number, status: string) => {
+        router.post(`/admin/moderation/comments/${id}`, { status });
+    };
+
+    return (
+        <>
+            <Head title="Moderation" />
+            <main className="mx-auto max-w-3xl px-6 py-12">
+                <h1 className="text-2xl font-semibold">Moderation queue</h1>
+
+                <section className="mt-8">
+                    <h2 className="text-lg font-medium">Profiles ({profiles.length})</h2>
+                    <ul className="mt-4 flex flex-col gap-4">
+                        {profiles.map((profile) => (
+                            <li key={profile.id} className="rounded border p-4">
+                                <p className="font-medium">{profile.display_name ?? 'Untitled'}</p>
+                                <p className="text-sm text-neutral-600">Account: {profile.user_name}</p>
+                                {profile.bio && <p className="mt-2 text-sm">{profile.bio}</p>}
+                                <div className="mt-3 flex gap-2">
+                                    <button
+                                        type="button"
+                                        className="rounded bg-green-700 px-3 py-1 text-sm text-white"
+                                        onClick={() => moderateProfile(profile.id, 'approved')}
+                                    >
+                                        Approve
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="rounded bg-red-700 px-3 py-1 text-sm text-white"
+                                        onClick={() => moderateProfile(profile.id, 'rejected')}
+                                    >
+                                        Reject
+                                    </button>
+                                </div>
+                            </li>
+                        ))}
+                        {profiles.length === 0 && <li className="text-sm text-neutral-600">No pending profiles.</li>}
+                    </ul>
+                </section>
+
+                <section className="mt-10">
+                    <h2 className="text-lg font-medium">Comments ({comments.length})</h2>
+                    <ul className="mt-4 flex flex-col gap-4">
+                        {comments.map((comment) => (
+                            <li key={comment.id} className="rounded border p-4">
+                                <p className="text-sm text-neutral-600">
+                                    {comment.user_name} on {comment.post_title}
+                                </p>
+                                <p className="mt-2">{comment.body}</p>
+                                <div className="mt-3 flex gap-2">
+                                    <button
+                                        type="button"
+                                        className="rounded bg-green-700 px-3 py-1 text-sm text-white"
+                                        onClick={() => moderateComment(comment.id, 'approved')}
+                                    >
+                                        Approve
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="rounded bg-red-700 px-3 py-1 text-sm text-white"
+                                        onClick={() => moderateComment(comment.id, 'rejected')}
+                                    >
+                                        Reject
+                                    </button>
+                                </div>
+                            </li>
+                        ))}
+                        {comments.length === 0 && <li className="text-sm text-neutral-600">No pending comments.</li>}
+                    </ul>
+                </section>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Articles/Show.tsx
+++ b/resources/js/Pages/Articles/Show.tsx
@@ -1,4 +1,19 @@
-import { Head, Link } from '@inertiajs/react';
+import { Head, Link, router, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+type Comment = {
+    id: number;
+    body: string;
+    created_at: string | null;
+    author: { display_name: string; avatar_url: string | null };
+};
+
+type Reactions = {
+    helpful: number;
+    support: number;
+    thank_you: number;
+    mine: string[];
+};
 
 type Article = {
     title: string;
@@ -14,7 +29,40 @@ type Article = {
     tags?: string[];
 };
 
-export default function ArticleShow({ article, preview }: { article: Article; preview?: boolean }) {
+const reactionLabels: Record<string, string> = {
+    helpful: 'Helpful',
+    support: 'Support',
+    thank_you: 'Thank You',
+};
+
+export default function ArticleShow({
+    article,
+    preview,
+    comments = [],
+    reactions = { helpful: 0, support: 0, thank_you: 0, mine: [] },
+    canEngage = false,
+    status,
+}: {
+    article: Article;
+    preview?: boolean;
+    comments?: Comment[];
+    reactions?: Reactions;
+    canEngage?: boolean;
+    status?: string;
+}) {
+    const commentForm = useForm({ body: '' });
+
+    const submitComment: FormEventHandler = (e) => {
+        e.preventDefault();
+        commentForm.post(`/articles/${article.slug}/comments`, {
+            onSuccess: () => commentForm.reset('body'),
+        });
+    };
+
+    const toggleReaction = (type: string) => {
+        router.post(`/articles/${article.slug}/reactions`, { type }, { preserveScroll: true });
+    };
+
     return (
         <>
             <Head title={article.meta_title}>
@@ -53,6 +101,91 @@ export default function ArticleShow({ article, preview }: { article: Article; pr
                         dangerouslySetInnerHTML={{ __html: article.html }}
                     />
                 </article>
+
+                {!preview && (
+                    <section className="mt-12 border-t border-neutral-200 pt-8" aria-label="Reactions">
+                        <h2 className="text-lg font-medium">Reactions</h2>
+                        <div className="mt-3 flex flex-wrap gap-3">
+                            {Object.entries(reactionLabels).map(([type, label]) => {
+                                const active = reactions.mine.includes(type);
+                                const count = reactions[type as keyof Omit<Reactions, 'mine'>] ?? 0;
+                                return (
+                                    <button
+                                        key={type}
+                                        type="button"
+                                        disabled={!canEngage}
+                                        onClick={() => toggleReaction(type)}
+                                        aria-pressed={active}
+                                        className={`rounded border px-3 py-1.5 text-sm ${active ? 'border-apes-primary bg-apes-primary/10' : 'border-neutral-300'}`}
+                                    >
+                                        {label} <span className="tabular-nums">({count})</span>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                        {!canEngage && (
+                            <p className="mt-2 text-sm text-neutral-600">
+                                <Link href="/login" className="underline">
+                                    Sign in
+                                </Link>{' '}
+                                with a verified account to react.
+                            </p>
+                        )}
+                    </section>
+                )}
+
+                {!preview && (
+                    <section className="mt-10 border-t border-neutral-200 pt-8" aria-label="Comments">
+                        <h2 className="text-lg font-medium">Comments</h2>
+                        {status === 'comment-pending' && (
+                            <p className="mt-2 text-sm text-green-700">Thanks — your comment is awaiting moderation.</p>
+                        )}
+
+                        <ul className="mt-4 flex flex-col gap-4">
+                            {comments.map((comment) => (
+                                <li key={comment.id} className="border-b border-neutral-100 pb-4">
+                                    <p className="text-sm font-medium">{comment.author.display_name}</p>
+                                    <p className="mt-1 text-neutral-800">{comment.body}</p>
+                                </li>
+                            ))}
+                            {comments.length === 0 && <li className="text-sm text-neutral-600">No approved comments yet.</li>}
+                        </ul>
+
+                        {canEngage ? (
+                            <form onSubmit={submitComment} className="mt-6 flex flex-col gap-3">
+                                <label htmlFor="comment-body" className="text-sm font-medium">
+                                    Add a comment
+                                </label>
+                                <textarea
+                                    id="comment-body"
+                                    value={commentForm.data.body}
+                                    onChange={(e) => commentForm.setData('body', e.target.value)}
+                                    rows={3}
+                                    required
+                                    maxLength={2000}
+                                    className="w-full rounded border px-3 py-2"
+                                />
+                                {commentForm.errors.body && (
+                                    <p className="text-sm text-red-600">{commentForm.errors.body}</p>
+                                )}
+                                <button
+                                    type="submit"
+                                    disabled={commentForm.processing}
+                                    className="w-fit rounded bg-apes-primary px-4 py-2 text-white"
+                                >
+                                    Submit for moderation
+                                </button>
+                            </form>
+                        ) : (
+                            <p className="mt-4 text-sm text-neutral-600">
+                                <Link href="/login" className="underline">
+                                    Sign in
+                                </Link>{' '}
+                                with a verified account to comment.
+                            </p>
+                        )}
+                    </section>
+                )}
             </main>
         </>
     );

--- a/resources/js/Pages/Mailing/Confirmed.tsx
+++ b/resources/js/Pages/Mailing/Confirmed.tsx
@@ -1,0 +1,16 @@
+import { Head, Link } from '@inertiajs/react';
+
+export default function Confirmed({ list }: { list: string }) {
+    return (
+        <>
+            <Head title="Subscription confirmed" />
+            <main className="mx-auto max-w-lg px-6 py-12">
+                <h1 className="text-2xl font-semibold">Subscription confirmed</h1>
+                <p className="mt-2 text-neutral-700">You are confirmed for {list}.</p>
+                <p className="mt-6 text-sm">
+                    <Link href="/">Back to home</Link>
+                </p>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Mailing/Preferences.tsx
+++ b/resources/js/Pages/Mailing/Preferences.tsx
@@ -1,0 +1,74 @@
+import { Head, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+type ListState = { list: string; label: string; purpose: string; status: string | null };
+
+export default function Preferences({
+    email,
+    lists,
+    signed,
+    status,
+}: {
+    email: string;
+    lists: ListState[];
+    signed: boolean;
+    status?: string;
+}) {
+    const initial = lists.filter((l) => l.status === 'confirmed' || l.status === 'pending').map((l) => l.list);
+
+    const { data, setData, post, processing, errors } = useForm<{ lists: string[] }>({
+        lists: initial,
+    });
+
+    const toggleList = (value: string) => {
+        setData(
+            'lists',
+            data.lists.includes(value) ? data.lists.filter((l) => l !== value) : [...data.lists, value],
+        );
+    };
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        post(signed ? window.location.pathname + window.location.search : '/account/mailing');
+    };
+
+    return (
+        <>
+            <Head title="Mailing preferences" />
+            <main className="mx-auto max-w-lg px-6 py-12">
+                <h1 className="text-2xl font-semibold">Mailing preferences</h1>
+                <p className="mt-2 text-sm text-neutral-600">Manage lists for {email}. New lists need email confirmation.</p>
+
+                {status === 'preferences-updated' && (
+                    <p className="mt-4 text-sm text-green-700">Preferences saved. Confirm any new lists via email.</p>
+                )}
+
+                <form onSubmit={submit} className="mt-8 flex flex-col gap-4">
+                    <fieldset className="flex flex-col gap-3">
+                        <legend className="font-medium">Lists</legend>
+                        {lists.map((list) => (
+                            <label key={list.list} className="flex gap-3 text-sm">
+                                <input
+                                    type="checkbox"
+                                    checked={data.lists.includes(list.list)}
+                                    onChange={() => toggleList(list.list)}
+                                />
+                                <span>
+                                    <span className="font-medium">{list.label}</span>
+                                    {list.status && (
+                                        <span className="ml-2 text-xs text-neutral-500">({list.status})</span>
+                                    )}
+                                    <span className="block text-neutral-600">{list.purpose}</span>
+                                </span>
+                            </label>
+                        ))}
+                        {errors.lists && <p className="text-sm text-red-600">{errors.lists}</p>}
+                    </fieldset>
+                    <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
+                        Save preferences
+                    </button>
+                </form>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Mailing/Signup.tsx
+++ b/resources/js/Pages/Mailing/Signup.tsx
@@ -1,0 +1,77 @@
+import { Head, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+type ListOption = { value: string; label: string; purpose: string };
+
+export default function Signup({ lists, status }: { lists: ListOption[]; status?: string }) {
+    const { data, setData, post, processing, errors } = useForm<{ email: string; lists: string[] }>({
+        email: '',
+        lists: [],
+    });
+
+    const toggleList = (value: string) => {
+        setData(
+            'lists',
+            data.lists.includes(value) ? data.lists.filter((l) => l !== value) : [...data.lists, value],
+        );
+    };
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        post('/mailing/signup');
+    };
+
+    return (
+        <>
+            <Head title="Mailing lists" />
+            <main className="mx-auto max-w-lg px-6 py-12">
+                <h1 className="text-2xl font-semibold">APES Newsroom mailing lists</h1>
+                <p className="mt-2 text-sm text-neutral-600">
+                    Choose which APES lists you want. Nothing is pre-selected. We will email you a confirmation
+                    link for each list before sending any news.
+                </p>
+
+                {status === 'check-email' && (
+                    <p className="mt-4 text-sm text-green-700">Check your email to confirm each list you selected.</p>
+                )}
+
+                <form onSubmit={submit} className="mt-8 flex flex-col gap-4">
+                    <div>
+                        <label htmlFor="email">Email address</label>
+                        <input
+                            id="email"
+                            type="email"
+                            required
+                            value={data.email}
+                            onChange={(e) => setData('email', e.target.value)}
+                            className="w-full rounded border px-3 py-2"
+                        />
+                        {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
+                    </div>
+
+                    <fieldset className="flex flex-col gap-3">
+                        <legend className="font-medium">Lists</legend>
+                        {lists.map((list) => (
+                            <label key={list.value} className="flex gap-3 text-sm">
+                                <input
+                                    type="checkbox"
+                                    checked={data.lists.includes(list.value)}
+                                    onChange={() => toggleList(list.value)}
+                                />
+                                <span>
+                                    <span className="font-medium">{list.label}</span>
+                                    <span className="block text-neutral-600">{list.purpose}</span>
+                                </span>
+                            </label>
+                        ))}
+                        {errors.lists && <p className="text-sm text-red-600">{errors.lists}</p>}
+                    </fieldset>
+
+                    <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
+                        Subscribe
+                    </button>
+                </form>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Mailing/Unsubscribe.tsx
+++ b/resources/js/Pages/Mailing/Unsubscribe.tsx
@@ -1,0 +1,55 @@
+import { Head, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+type ListOption = { value: string; label: string };
+
+export default function Unsubscribe({ email, lists }: { email: string; lists: ListOption[] }) {
+    const { data, setData, post, processing } = useForm<{ list: string; all: boolean }>({
+        list: '',
+        all: false,
+    });
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        post(window.location.pathname + window.location.search);
+    };
+
+    return (
+        <>
+            <Head title="Unsubscribe" />
+            <main className="mx-auto max-w-lg px-6 py-12">
+                <h1 className="text-2xl font-semibold">Unsubscribe</h1>
+                <p className="mt-2 text-sm text-neutral-600">Update mailing preferences for {email}. No login required.</p>
+
+                <form onSubmit={submit} className="mt-8 flex flex-col gap-4">
+                    <fieldset className="flex flex-col gap-3">
+                        <legend className="font-medium">Leave a specific list</legend>
+                        {lists.map((list) => (
+                            <label key={list.value} className="flex gap-3 text-sm">
+                                <input
+                                    type="radio"
+                                    name="list"
+                                    checked={!data.all && data.list === list.value}
+                                    onChange={() => setData({ list: list.value, all: false })}
+                                />
+                                {list.label}
+                            </label>
+                        ))}
+                        <label className="flex gap-3 text-sm font-medium">
+                            <input
+                                type="radio"
+                                name="list"
+                                checked={data.all}
+                                onChange={() => setData({ list: '', all: true })}
+                            />
+                            Unsubscribe from all lists
+                        </label>
+                    </fieldset>
+                    <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
+                        Confirm
+                    </button>
+                </form>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Profiles/Show.tsx
+++ b/resources/js/Pages/Profiles/Show.tsx
@@ -1,0 +1,26 @@
+import { Head } from '@inertiajs/react';
+
+type Profile = {
+    display_name: string;
+    bio: string | null;
+    avatar_url: string | null;
+};
+
+export default function ProfileShow({ profile }: { profile: Profile }) {
+    return (
+        <>
+            <Head title={profile.display_name} />
+            <main className="mx-auto max-w-lg px-6 py-12">
+                {profile.avatar_url && (
+                    <img
+                        src={profile.avatar_url}
+                        alt=""
+                        className="h-24 w-24 rounded-full object-cover"
+                    />
+                )}
+                <h1 className="mt-4 text-2xl font-semibold">{profile.display_name}</h1>
+                {profile.bio && <p className="mt-3 text-neutral-700">{profile.bio}</p>}
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Staff/Campaigns/Preview.tsx
+++ b/resources/js/Pages/Staff/Campaigns/Preview.tsx
@@ -1,0 +1,71 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+type Snapshot = {
+    title: string;
+    excerpt: string | null;
+    author: string;
+    channel_label: string;
+    published_at: string | null;
+    read_more_url: string;
+};
+
+export default function CampaignPreview({
+    post,
+    snapshot,
+    status,
+}: {
+    post: { id: number; title: string; status: string; email_on_publish: boolean; mailing_lists: string[] };
+    snapshot: Snapshot;
+    status?: string;
+}) {
+    const { data, setData, post: submit, processing, errors } = useForm({ email: '' });
+
+    const sendTest: FormEventHandler = (e) => {
+        e.preventDefault();
+        submit(`/staff/posts/${post.id}/campaign/test-send`);
+    };
+
+    return (
+        <>
+            <Head title={`Campaign preview: ${post.title}`} />
+            <main className="mx-auto max-w-2xl px-6 py-12">
+                <Link href={`/staff/posts/${post.id}/edit`} className="text-sm underline">
+                    ← Back to post
+                </Link>
+                <h1 className="mt-4 text-2xl font-semibold">Campaign preview</h1>
+                {status === 'test-send-queued' && (
+                    <p className="mt-2 text-sm text-green-700">Test send queued. It cannot trigger a live campaign.</p>
+                )}
+
+                <article className="mt-8 rounded border border-neutral-200 p-6">
+                    <p className="text-sm text-neutral-600">
+                        {snapshot.channel_label} · {snapshot.author}
+                    </p>
+                    <h2 className="mt-2 text-xl font-semibold">{snapshot.title}</h2>
+                    {snapshot.excerpt && <p className="mt-3 text-neutral-700">{snapshot.excerpt}</p>}
+                    <a href={snapshot.read_more_url} className="mt-4 inline-block text-sm underline">
+                        Read the full story
+                    </a>
+                </article>
+
+                <form onSubmit={sendTest} className="mt-8 flex flex-col gap-3 border-t pt-6">
+                    <h2 className="font-medium">Test send</h2>
+                    <p className="text-sm text-neutral-600">Enter an explicit recipient. Never pre-filled from live lists.</p>
+                    <input
+                        type="email"
+                        required
+                        value={data.email}
+                        onChange={(e) => setData('email', e.target.value)}
+                        placeholder="you@example.com"
+                        className="w-full max-w-md rounded border px-3 py-2"
+                    />
+                    {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
+                    <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
+                        Queue test send
+                    </button>
+                </form>
+            </main>
+        </>
+    );
+}

--- a/resources/js/Pages/Staff/Posts/Edit.tsx
+++ b/resources/js/Pages/Staff/Posts/Edit.tsx
@@ -2,6 +2,7 @@ import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
 
 type Channel = { value: string; label: string };
+type MailingListOption = { value: string; label: string };
 
 type PostData = {
     id: number;
@@ -14,6 +15,8 @@ type PostData = {
     meta_title: string | null;
     meta_description: string | null;
     scheduled_for: string | null;
+    email_on_publish: boolean;
+    mailing_lists: string[];
 };
 
 const emptyContent = {
@@ -30,9 +33,19 @@ type PostForm = {
     channel: string;
     meta_title: string;
     meta_description: string;
+    email_on_publish: boolean;
+    mailing_lists: string[];
 };
 
-export default function PostEdit({ post, channels }: { post: PostData | null; channels: Channel[] }) {
+export default function PostEdit({
+    post,
+    channels,
+    mailingLists,
+}: {
+    post: PostData | null;
+    channels: Channel[];
+    mailingLists: MailingListOption[];
+}) {
     const isNew = post === null;
 
     const { data, setData, post: submitPost, patch, processing, errors } = useForm<PostForm>({
@@ -43,6 +56,8 @@ export default function PostEdit({ post, channels }: { post: PostData | null; ch
         channel: post?.channel ?? channels[0]?.value ?? 'apes_cic',
         meta_title: post?.meta_title ?? '',
         meta_description: post?.meta_description ?? '',
+        email_on_publish: post?.email_on_publish ?? false,
+        mailing_lists: post?.mailing_lists ?? [],
     });
 
     const submit: FormEventHandler = (e) => {
@@ -61,6 +76,15 @@ export default function PostEdit({ post, channels }: { post: PostData | null; ch
         });
     };
 
+    const toggleList = (value: string) => {
+        setData(
+            'mailing_lists',
+            data.mailing_lists.includes(value)
+                ? data.mailing_lists.filter((l) => l !== value)
+                : [...data.mailing_lists, value],
+        );
+    };
+
     const bodyText = data.content.blocks[0]?.data?.text ?? '';
 
     return (
@@ -76,6 +100,10 @@ export default function PostEdit({ post, channels }: { post: PostData | null; ch
                         Status: {post.status}{' '}
                         <Link href={`/staff/posts/${post.id}/preview`} className="underline">
                             Preview
+                        </Link>
+                        {' · '}
+                        <Link href={`/staff/posts/${post.id}/campaign`} className="underline">
+                            Campaign preview
                         </Link>
                     </p>
                 )}
@@ -136,6 +164,33 @@ export default function PostEdit({ post, channels }: { post: PostData | null; ch
                         />
                         {errors.content && <p className="text-sm text-red-600">{errors.content}</p>}
                     </div>
+
+                    <fieldset className="flex flex-col gap-3 border-t pt-4">
+                        <legend className="font-medium">Email campaign</legend>
+                        <label className="flex gap-2 text-sm">
+                            <input
+                                type="checkbox"
+                                checked={data.email_on_publish}
+                                onChange={(e) => setData('email_on_publish', e.target.checked)}
+                            />
+                            Email this post on publish
+                        </label>
+                        {data.email_on_publish && (
+                            <div className="flex flex-col gap-2 pl-6">
+                                {mailingLists.map((list) => (
+                                    <label key={list.value} className="flex gap-2 text-sm">
+                                        <input
+                                            type="checkbox"
+                                            checked={data.mailing_lists.includes(list.value)}
+                                            onChange={() => toggleList(list.value)}
+                                        />
+                                        {list.label}
+                                    </label>
+                                ))}
+                            </div>
+                        )}
+                    </fieldset>
+
                     <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
                         {isNew ? 'Create draft' : 'Save'}
                     </button>

--- a/resources/views/mail/campaign-post-summary.blade.php
+++ b/resources/views/mail/campaign-post-summary.blade.php
@@ -1,0 +1,24 @@
+<x-mail::message>
+@if ($isTest)
+**TEST SEND** — this message was not sent to the live mailing list.
+@endif
+
+# {{ $snapshot['title'] }}
+
+**{{ $snapshot['channel_label'] }}** · {{ $snapshot['author'] }}@if (!empty($snapshot['published_at'])) · {{ \Illuminate\Support\Carbon::parse($snapshot['published_at'])->timezone('Europe/London')->format('j M Y') }}@endif
+
+@if (!empty($snapshot['excerpt']))
+{{ $snapshot['excerpt'] }}
+@endif
+
+<x-mail::button :url="$snapshot['read_more_url']">
+Read the full story
+</x-mail::button>
+
+Thanks,<br>
+{{ config('app.name') }}
+
+<x-mail::subcopy>
+APES CIC · Manage your [preferences]({{ $preferencesUrl }}) or [unsubscribe]({{ $unsubscribeUrl }}).
+</x-mail::subcopy>
+</x-mail::message>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,13 +2,22 @@
 
 use App\Enums\Role;
 use App\Http\Controllers\AccountController;
+use App\Http\Controllers\Admin\ModerationController;
 use App\Http\Controllers\ArticleController;
 use App\Http\Controllers\ChannelController;
+use App\Http\Controllers\CommentController;
 use App\Http\Controllers\HealthController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\Mailing\ConfirmController;
+use App\Http\Controllers\Mailing\PreferenceController;
+use App\Http\Controllers\Mailing\SignupController;
+use App\Http\Controllers\Mailing\UnsubscribeController;
+use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\ReactionController;
 use App\Http\Controllers\RssController;
 use App\Http\Controllers\SearchController;
 use App\Http\Controllers\SitemapController;
+use App\Http\Controllers\Staff\CampaignController as StaffCampaignController;
 use App\Http\Controllers\Staff\PostController as StaffPostController;
 use Illuminate\Support\Facades\Route;
 
@@ -20,6 +29,17 @@ Route::get('/rss.xml', [RssController::class, 'index'])->name('rss');
 
 Route::get('/search', [SearchController::class, 'index'])->name('search');
 Route::get('/articles/{slug}', [ArticleController::class, 'show'])->name('articles.show');
+Route::get('/profiles/{profile}', [ProfileController::class, 'show'])->name('profiles.show');
+
+Route::get('/mailing/signup', [SignupController::class, 'show'])->name('mailing.signup');
+Route::post('/mailing/signup', [SignupController::class, 'store'])->name('mailing.signup.store');
+Route::get('/mailing/confirm/{token}', ConfirmController::class)->name('mailing.confirm');
+Route::get('/mailing/preferences', [PreferenceController::class, 'showSigned'])->name('mailing.preferences.signed');
+Route::post('/mailing/preferences', [PreferenceController::class, 'updateSigned'])->name('mailing.preferences.signed.update');
+Route::get('/mailing/unsubscribe', [UnsubscribeController::class, 'show'])->name('mailing.unsubscribe');
+Route::post('/mailing/unsubscribe', [UnsubscribeController::class, 'store'])->name('mailing.unsubscribe.store');
+Route::post('/mailing/unsubscribe/one-click', [UnsubscribeController::class, 'oneClick'])->name('mailing.unsubscribe.one-click');
+
 Route::get('/{channel}', [ChannelController::class, 'show'])
     ->where('channel', 'apes-cic|apes-shelter-rescue|apes-pet-care-clinic')
     ->name('channels.show');
@@ -29,7 +49,26 @@ Route::middleware(['auth', 'verified'])->prefix('account')->name('account.')->gr
     Route::patch('/', [AccountController::class, 'update'])->name('update');
     Route::get('/export', [AccountController::class, 'export'])->name('export');
     Route::delete('/', [AccountController::class, 'destroy'])->name('destroy');
+    Route::get('/mailing', [PreferenceController::class, 'showAccount'])->name('mailing');
+    Route::post('/mailing', [PreferenceController::class, 'updateAccount'])->name('mailing.update');
+    Route::get('/public-profile', [ProfileController::class, 'edit'])->name('public-profile');
+    Route::post('/public-profile', [ProfileController::class, 'update'])->name('public-profile.update');
 });
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::post('/articles/{slug}/comments', [CommentController::class, 'store'])->name('articles.comments.store');
+    Route::patch('/comments/{comment}', [CommentController::class, 'update'])->name('comments.update');
+    Route::post('/articles/{slug}/reactions', [ReactionController::class, 'toggle'])->name('articles.reactions.toggle');
+});
+
+Route::middleware(['auth', 'verified', 'role:'.Role::Admin->value])
+    ->prefix('admin')
+    ->name('admin.')
+    ->group(function () {
+        Route::get('/moderation', [ModerationController::class, 'index'])->name('moderation.index');
+        Route::post('/moderation/profiles/{profile}', [ModerationController::class, 'moderateProfile'])->name('moderation.profiles');
+        Route::post('/moderation/comments/{comment}', [ModerationController::class, 'moderateComment'])->name('moderation.comments');
+    });
 
 Route::middleware(['auth', 'verified', 'role:'.Role::Staff->value])
     ->prefix('staff')
@@ -44,6 +83,8 @@ Route::middleware(['auth', 'verified', 'role:'.Role::Staff->value])
         Route::post('/posts/{post}/schedule', [StaffPostController::class, 'schedule'])->name('posts.schedule');
         Route::post('/posts/{post}/publish', [StaffPostController::class, 'publish'])->name('posts.publish');
         Route::get('/posts/{post}/preview', [StaffPostController::class, 'preview'])->name('posts.preview');
+        Route::get('/posts/{post}/campaign', [StaffCampaignController::class, 'preview'])->name('posts.campaign.preview');
+        Route::post('/posts/{post}/campaign/test-send', [StaffCampaignController::class, 'testSend'])->name('posts.campaign.test');
     });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/EngagementTest.php
+++ b/tests/Feature/EngagementTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ModerationStatus;
+use App\Enums\ReactionType;
+use App\Models\Comment;
+use App\Models\Post;
+use App\Models\Profile;
+use App\Models\Reaction;
+use App\Models\User;
+use App\Services\Engagement\ProfileService;
+use App\Services\Engagement\ReactionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EngagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_new_profiles_are_private_by_default(): void
+    {
+        $user = User::factory()->create();
+        $profile = app(ProfileService::class)->forUser($user);
+
+        $this->assertSame(ModerationStatus::Private, $profile->moderation_status);
+        $this->assertFalse($profile->public_opt_in);
+        $this->assertNull($profile->publicPayload());
+        $this->get('/profiles/'.$profile->id)->assertNotFound();
+    }
+
+    public function test_profile_edits_require_moderation_before_public_display(): void
+    {
+        $user = User::factory()->create();
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($user)->post('/account/public-profile', [
+            'display_name' => 'River Reader',
+            'bio' => 'Loves exotic pets',
+            'public_opt_in' => true,
+        ])->assertRedirect();
+
+        $profile = Profile::query()->where('user_id', $user->id)->firstOrFail();
+        $this->assertSame(ModerationStatus::Pending, $profile->moderation_status);
+        $this->get('/profiles/'.$profile->id)->assertNotFound();
+
+        $this->actingAs($admin)->post('/admin/moderation/profiles/'.$profile->id, [
+            'status' => ModerationStatus::Approved->value,
+        ])->assertRedirect();
+
+        $this->get('/profiles/'.$profile->id)->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('Profiles/Show')
+                ->where('profile.display_name', 'River Reader')
+            );
+
+        $this->actingAs($user)->post('/account/public-profile', [
+            'display_name' => 'River Updated',
+            'bio' => 'Updated bio',
+            'public_opt_in' => true,
+        ])->assertRedirect();
+
+        $this->assertSame(ModerationStatus::Pending, $profile->fresh()->moderation_status);
+        $this->get('/profiles/'.$profile->id)->assertNotFound();
+    }
+
+    public function test_comments_require_moderation_and_hide_private_data(): void
+    {
+        $author = User::factory()->create();
+        $reader = User::factory()->create();
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->published()->create(['author_id' => $author->id, 'slug' => 'engage-story']);
+
+        $this->actingAs($reader)->post('/articles/engage-story/comments', [
+            'body' => 'Great update from the shelter',
+        ])->assertRedirect();
+
+        $comment = Comment::query()->firstOrFail();
+        $this->assertSame(ModerationStatus::Pending, $comment->moderation_status);
+
+        $this->get('/articles/engage-story')->assertOk()
+            ->assertInertia(fn ($page) => $page->has('comments', 0));
+
+        $this->actingAs($admin)->post('/admin/moderation/comments/'.$comment->id, [
+            'status' => ModerationStatus::Approved->value,
+        ])->assertRedirect();
+
+        $this->get('/articles/engage-story')->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->has('comments', 1)
+                ->where('comments.0.body', 'Great update from the shelter')
+                ->missing('comments.0.user_id')
+                ->missing('comments.0.email')
+            );
+    }
+
+    public function test_suspended_accounts_cannot_interact(): void
+    {
+        $user = User::factory()->create();
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->published()->create(['author_id' => $admin->id, 'slug' => 'locked']);
+
+        $profile = app(ProfileService::class)->forUser($user);
+        app(ProfileService::class)->moderate($profile, $admin, ModerationStatus::Suspended, 'spam');
+
+        $this->actingAs($user)->post('/articles/locked/comments', [
+            'body' => 'Should fail',
+        ])->assertForbidden();
+
+        $this->actingAs($user)->post('/articles/locked/reactions', [
+            'type' => ReactionType::Helpful->value,
+        ])->assertForbidden();
+    }
+
+    public function test_reaction_uniqueness_holds_under_toggle(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->published()->create(['slug' => 'react-me']);
+
+        $service = app(ReactionService::class);
+
+        $this->assertTrue($service->toggle($user, $post, ReactionType::Helpful));
+        $this->assertFalse($service->toggle($user, $post, ReactionType::Helpful));
+        $this->assertTrue($service->toggle($user, $post, ReactionType::Support));
+
+        $this->assertSame(1, Reaction::query()->where('user_id', $user->id)->where('post_id', $post->id)->where('type', ReactionType::Support)->count());
+        $this->assertSame(0, Reaction::query()->where('user_id', $user->id)->where('post_id', $post->id)->where('type', ReactionType::Helpful)->count());
+
+        $this->actingAs($user)->post('/articles/react-me/reactions', [
+            'type' => ReactionType::ThankYou->value,
+        ])->assertRedirect();
+
+        $this->actingAs($user)->post('/articles/react-me/reactions', [
+            'type' => ReactionType::ThankYou->value,
+        ])->assertRedirect();
+
+        $this->assertSame(0, Reaction::query()->where('type', ReactionType::ThankYou)->count());
+    }
+
+    public function test_public_article_payload_does_not_expose_moderation_notes(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $reader = User::factory()->create();
+        $post = Post::factory()->published()->create(['author_id' => $admin->id, 'slug' => 'clean']);
+
+        $comment = Comment::create([
+            'post_id' => $post->id,
+            'user_id' => $reader->id,
+            'body' => 'Visible later',
+            'body_hash' => hash('sha256', 'visible later'),
+            'moderation_status' => ModerationStatus::Approved,
+            'moderation_notes' => 'internal reason',
+        ]);
+
+        $this->get('/articles/clean')->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('comments.0.id', $comment->id)
+                ->missing('comments.0.moderation_notes')
+            );
+    }
+
+    public function test_staff_cannot_access_admin_moderation(): void
+    {
+        $staff = User::factory()->staff()->create();
+        $this->actingAs($staff)->get('/admin/moderation')->assertForbidden();
+    }
+
+    public function test_unverified_users_cannot_comment(): void
+    {
+        $user = User::factory()->unverified()->create();
+        $post = Post::factory()->published()->create(['slug' => 'verify-first']);
+
+        $this->actingAs($user)->post('/articles/verify-first/comments', [
+            'body' => 'Nope',
+        ])->assertRedirect(); // verified middleware redirects
+    }
+}

--- a/tests/Feature/MailingConsentTest.php
+++ b/tests/Feature/MailingConsentTest.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\CampaignRecipientStatus;
+use App\Enums\CampaignStatus;
+use App\Enums\MailingList;
+use App\Enums\PostStatus;
+use App\Enums\SubscriptionStatus;
+use App\Jobs\SendCampaignRecipientJob;
+use App\Mail\CampaignPostSummaryMail;
+use App\Models\Campaign;
+use App\Models\CampaignRecipient;
+use App\Models\MailingContact;
+use App\Models\MailingListSubscription;
+use App\Models\Post;
+use App\Models\Suppression;
+use App\Models\User;
+use App\Notifications\ConfirmMailingListNotification;
+use App\Services\Mailing\CampaignService;
+use App\Services\Mailing\ConsentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class MailingConsentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_signup_requires_at_least_one_list_and_none_preselected(): void
+    {
+        $this->get('/mailing/signup')->assertOk()->assertInertia(fn ($page) => $page
+            ->component('Mailing/Signup')
+            ->has('lists', 3)
+        );
+
+        $this->post('/mailing/signup', [
+            'email' => 'reader@example.com',
+            'lists' => [],
+        ])->assertSessionHasErrors('lists');
+    }
+
+    public function test_signup_sends_double_opt_in_and_confirm_activates_list(): void
+    {
+        Notification::fake();
+
+        $this->post('/mailing/signup', [
+            'email' => 'reader@example.com',
+            'lists' => [MailingList::ApesCic->value],
+        ])->assertRedirect();
+
+        $contact = MailingContact::query()->where('email', 'reader@example.com')->firstOrFail();
+        $subscription = $contact->subscriptions()->firstOrFail();
+
+        $this->assertSame(SubscriptionStatus::Pending, $subscription->status);
+
+        Notification::assertSentTo($contact, ConfirmMailingListNotification::class);
+
+        $this->get('/mailing/confirm/'.$subscription->confirm_token)->assertOk();
+
+        $this->assertSame(SubscriptionStatus::Confirmed, $subscription->fresh()->status);
+        $this->assertDatabaseHas('consent_events', [
+            'email' => 'reader@example.com',
+            'action' => 'confirmed',
+            'list' => MailingList::ApesCic->value,
+        ]);
+    }
+
+    public function test_unsubscribe_takes_effect_before_send_without_auth(): void
+    {
+        Mail::fake();
+
+        $contact = MailingContact::factory()->create(['email' => 'reader@example.com']);
+        MailingListSubscription::create([
+            'mailing_contact_id' => $contact->id,
+            'list' => MailingList::ApesCic,
+            'status' => SubscriptionStatus::Confirmed,
+            'confirmed_at' => now(),
+        ]);
+
+        $url = URL::temporarySignedRoute(
+            'mailing.unsubscribe.one-click',
+            now()->addDay(),
+            ['email' => 'reader@example.com'],
+        );
+
+        $this->post($url)->assertNoContent();
+
+        $this->assertSame(
+            SubscriptionStatus::Unsubscribed,
+            $contact->subscriptions()->first()->fresh()->status,
+        );
+
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->create([
+            'author_id' => $admin->id,
+            'email_on_publish' => true,
+            'mailing_lists' => [MailingList::ApesCic->value],
+            'status' => PostStatus::Draft,
+        ]);
+
+        $this->actingAs($admin)->post("/staff/posts/{$post->id}/publish")->assertRedirect();
+
+        $campaign = Campaign::query()->where('post_id', $post->id)->where('is_test', false)->first();
+        $this->assertNotNull($campaign);
+        $this->assertSame(0, $campaign->recipients()->count());
+    }
+
+    public function test_suppressed_contacts_never_receive_campaign_mail(): void
+    {
+        Mail::fake();
+
+        Suppression::create(['email' => 'blocked@example.com', 'reason' => 'objection']);
+
+        $contact = MailingContact::factory()->create(['email' => 'blocked@example.com']);
+        MailingListSubscription::create([
+            'mailing_contact_id' => $contact->id,
+            'list' => MailingList::ApesCic,
+            'status' => SubscriptionStatus::Confirmed,
+            'confirmed_at' => now(),
+        ]);
+
+        $emails = app(ConsentService::class)->confirmedEmailsForLists([MailingList::ApesCic]);
+        $this->assertNotContains('blocked@example.com', $emails);
+    }
+
+    public function test_multi_list_recipients_are_de_duplicated(): void
+    {
+        $contact = MailingContact::factory()->create(['email' => 'multi@example.com']);
+
+        foreach ([MailingList::ApesCic, MailingList::ApesShelterRescue] as $list) {
+            MailingListSubscription::create([
+                'mailing_contact_id' => $contact->id,
+                'list' => $list,
+                'status' => SubscriptionStatus::Confirmed,
+                'confirmed_at' => now(),
+            ]);
+        }
+
+        $emails = app(ConsentService::class)->confirmedEmailsForLists([
+            MailingList::ApesCic,
+            MailingList::ApesShelterRescue,
+        ]);
+
+        $this->assertSame(['multi@example.com'], $emails);
+    }
+
+    public function test_publish_creates_immutable_campaign_snapshot_once(): void
+    {
+        Mail::fake();
+
+        $contact = MailingContact::factory()->create(['email' => 'reader@example.com']);
+        MailingListSubscription::create([
+            'mailing_contact_id' => $contact->id,
+            'list' => MailingList::ApesCic,
+            'status' => SubscriptionStatus::Confirmed,
+            'confirmed_at' => now(),
+        ]);
+
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->create([
+            'author_id' => $admin->id,
+            'title' => 'Original Title',
+            'excerpt' => 'Original excerpt',
+            'email_on_publish' => true,
+            'mailing_lists' => [MailingList::ApesCic->value],
+        ]);
+
+        $this->actingAs($admin)->post("/staff/posts/{$post->id}/publish")->assertRedirect();
+        $this->actingAs($admin)->post("/staff/posts/{$post->id}/publish")->assertRedirect();
+
+        $this->assertSame(1, Campaign::query()->where('post_id', $post->id)->where('is_test', false)->count());
+
+        $campaign = Campaign::query()->where('post_id', $post->id)->first();
+        $this->assertSame('Original Title', $campaign->snapshot['title']);
+
+        $post->update(['title' => 'Changed After Publish']);
+        $this->assertSame('Original Title', $campaign->fresh()->snapshot['title']);
+    }
+
+    public function test_test_send_cannot_become_live_campaign(): void
+    {
+        Mail::fake();
+
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->create([
+            'author_id' => $admin->id,
+            'email_on_publish' => true,
+            'mailing_lists' => [MailingList::ApesCic->value],
+        ]);
+
+        $this->actingAs($admin)->post("/staff/posts/{$post->id}/campaign/test-send", [
+            'email' => 'tester@example.com',
+        ])->assertRedirect();
+
+        $test = Campaign::query()->where('is_test', true)->firstOrFail();
+        $this->assertTrue($test->is_test);
+        $this->assertSame('tester@example.com', $test->test_recipient);
+        $this->assertSame(0, Campaign::query()->where('is_test', false)->count());
+
+        Mail::assertSent(CampaignPostSummaryMail::class, function (CampaignPostSummaryMail $mail) {
+            return $mail->isTest === true
+                && $mail->hasTo('tester@example.com');
+        });
+    }
+
+    public function test_campaign_mail_includes_list_unsubscribe_headers(): void
+    {
+        Mail::fake();
+
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->published()->create([
+            'author_id' => $admin->id,
+            'title' => 'Header Check',
+            'email_on_publish' => true,
+            'mailing_lists' => [MailingList::ApesCic->value],
+        ]);
+
+        $campaign = Campaign::create([
+            'post_id' => $post->id,
+            'created_by' => $admin->id,
+            'lists' => [MailingList::ApesCic->value],
+            'snapshot' => app(CampaignService::class)->buildSnapshot($post),
+            'status' => CampaignStatus::Sending,
+            'is_test' => true,
+            'test_recipient' => 'headers@example.com',
+            'queued_at' => now(),
+        ]);
+
+        $recipient = CampaignRecipient::create([
+            'campaign_id' => $campaign->id,
+            'email' => 'headers@example.com',
+            'status' => CampaignRecipientStatus::Queued,
+            'idempotency_key' => hash('sha256', $campaign->id.'|headers@example.com'),
+        ]);
+
+        (new SendCampaignRecipientJob($recipient->id))->handle(app(ConsentService::class));
+
+        Mail::assertSent(CampaignPostSummaryMail::class, function (CampaignPostSummaryMail $mail) {
+            $headers = $mail->headers();
+
+            return str_contains($headers->text['List-Unsubscribe'] ?? '', 'http')
+                && ($headers->text['List-Unsubscribe-Post'] ?? '') === 'List-Unsubscribe=One-Click';
+        });
+    }
+
+    public function test_recipient_job_is_idempotent_after_acceptance(): void
+    {
+        Mail::fake();
+
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->published()->create(['author_id' => $admin->id]);
+
+        $campaign = Campaign::create([
+            'post_id' => $post->id,
+            'created_by' => $admin->id,
+            'lists' => [MailingList::ApesCic->value],
+            'snapshot' => ['title' => 'T', 'excerpt' => null, 'author' => 'A', 'channel' => 'apes_cic', 'channel_label' => 'APES CIC', 'read_more_url' => 'http://localhost/articles/x', 'slug' => 'x'],
+            'status' => CampaignStatus::Sending,
+            'is_test' => true,
+            'test_recipient' => 'once@example.com',
+            'queued_at' => now(),
+        ]);
+
+        $recipient = CampaignRecipient::create([
+            'campaign_id' => $campaign->id,
+            'email' => 'once@example.com',
+            'status' => CampaignRecipientStatus::Queued,
+            'idempotency_key' => 'unique-key-1',
+        ]);
+
+        $job = new SendCampaignRecipientJob($recipient->id);
+        $job->handle(app(ConsentService::class));
+        $job->handle(app(ConsentService::class));
+
+        Mail::assertSent(CampaignPostSummaryMail::class, 1);
+        $this->assertSame(CampaignRecipientStatus::Accepted, $recipient->fresh()->status);
+    }
+
+    public function test_staff_cannot_test_send_campaign(): void
+    {
+        $staff = User::factory()->staff()->create();
+        $post = Post::factory()->create(['author_id' => $staff->id]);
+
+        $this->actingAs($staff)->post("/staff/posts/{$post->id}/campaign/test-send", [
+            'email' => 'x@example.com',
+        ])->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- Implements #7: double opt-in mailing lists, consent ledger, suppressions, preference/unsubscribe links, and queued post-summary campaigns with publish-time snapshots and admin test-send.
- Implements #8: private-by-default moderated profiles, pre-moderated comments, Helpful/Support/Thank You reactions, and an admin moderation queue.
- Updates the epic build plan next step toward #9 Ghost migration; does not authorize live campaigns or production cutover.

## Test plan
- [ ] `php artisan test` (includes `MailingConsentTest` and `EngagementTest`)
- [ ] `npm run typecheck`
- [ ] Signup at `/mailing/signup` with unchecked lists → confirm DOI email → preferences update
- [ ] Signed unsubscribe / one-click unsubscribe before a queued send
- [ ] Publish a post with email-this-post + lists → campaign snapshot created once; edit post does not resend
- [ ] Admin campaign preview + test-send to an explicit address only
- [ ] Submit public profile → pending until admin approve at `/admin/moderation`
- [ ] Verified user comment/reaction on an article; public payload has no email/moderation notes