### PR TITLE
docs: resequence Ghost mailing import to end (#18)

### DIFF
--- a/docs/epic-1-build-plan.md
+++ b/docs/epic-1-build-plan.md
@@ -1,10 +1,10 @@
 # Epic #1 build plan: APES Newsroom (replacing Ghost)
 
-Source: [Issue #1](https://github.com/APESCIC/APES-Newsroom/issues/1) and its ten sub-issues (#2–#11). Phases 0–3 are implemented in code on the main delivery branch; #2–#6 still have residual acceptance work (Editor.js UI, discovery polish) tracked on those issues.
+Source: [Issue #1](https://github.com/APESCIC/APES-Newsroom/issues/1) and its sub-issues (#2–#11, #18). Phases 0–3 are implemented in code on the main delivery branch; #2–#6 still have residual acceptance work (Editor.js UI, discovery polish) tracked on those issues.
 
 ## What we're building
 
-One Laravel 13 + Inertia/React app on the existing Cloudron LAMP app (`74a2a784-a161-4787-84ff-2b8efc957bc8`), with two surfaces: a public SEO newsroom for three APES channels (CIC, Shelter & Rescue, Pet Care Clinic), and authenticated workspaces for publishing, campaigns, moderation, and governance. Public accounts use password/magic-link login; staff use Cloudron OIDC + LDAP role mapping. Content is versioned Editor.js JSON with a server-enforced block allowlist. Mailing lists are per-channel, double opt-in, queued through Cloudron SMTP. Ghost content and members migrate in; Ghost isn't retired until a separately authorized cutover.
+One Laravel 13 + Inertia/React app on the existing Cloudron LAMP app (`74a2a784-a161-4787-84ff-2b8efc957bc8`), with two surfaces: a public SEO newsroom for three APES channels (CIC, Shelter & Rescue, Pet Care Clinic), and authenticated workspaces for publishing, campaigns, moderation, and governance. Public accounts use password/magic-link login; staff use Cloudron OIDC + LDAP role mapping. Content is versioned Editor.js JSON with a server-enforced block allowlist. Mailing lists are per-channel, double opt-in, queued through Cloudron SMTP. Ghost content and mailing lists are imported from Admin export files (content JSON + media archive, then members CSV); Ghost isn't retired until a separately authorized cutover.
 
 Shared contracts used across multiple issues: `Role` (public/staff/admin/super_admin), `PostStatus` (draft/in_review/scheduled/published/unpublished/deleted), `MailingList` (apes_cic/apes_shelter_rescue/apes_pet_care_clinic), `ModerationStatus` (private/pending/approved/rejected/suspended), `ReactionType` (helpful/support/thank_you).
 
@@ -15,52 +15,57 @@ Every sub-issue repeats some version of this, so it's worth stating once: comple
 ## Dependency map
 
 ```
-        ┌────────────┐   ┌──────────────────────┐
-        │ #2 Design  │   │ #3 Laravel foundation │
-        │ (IA/visual)│   │ (infra, CI, deploy)   │
-        └─────┬──────┘   └───────────┬───────────┘
-              │                      │
-              │              ┌───────▼────────┐
-              │              │ #4 Accounts &   │
-              │              │ Cloudron RBAC   │
-              │              └───────┬─────────┘
-              │                      │
-       ┌──────┴──────────────────────┼──────────────────┐
-       │                             │                  │
-┌──────▼───────┐            ┌────────▼────────┐         │
-│ #6 Public     │◄───────── │ #5 Editor.js     │         │
-│ newsroom/     │  content  │ publishing/SEO   │         │
-│ discovery     │           │ workflow         │         │
-└──────┬────────┘           └────────┬─────────┘         │
-       │                             │                   │
-       │                    ┌────────▼─────────┐         │
-       │                    │ #7 Mailing lists, │         │
-       │                    │ consent, campaigns│         │
-       │                    └────────┬─────────┘         │
-       │                             │                    │
-┌──────▼────────┐                    │                    │
-│ #8 Profiles,   │                    │                    │
-│ comments,      │                    │                    │
-│ reactions      │                    │                    │
-└──────┬─────────┘                    │                    │
-       │                             │                    │
-       └──────────────┬──────────────┴────────────────────┘
-                       │
-              ┌────────▼─────────┐
-              │ #9 Ghost migration │
-              │ (needs #5,#6,#7   │
-              │ target schemas)   │
-              └────────┬──────────┘
-                       │
-       #10 Governance (GDPR/PECR/security/a11y) ─ runs
+        +------------+   +----------------------+
+        | #2 Design  |   | #3 Laravel foundation |
+        | (IA/visual)|   | (infra, CI, deploy)   |
+        +-----+------+   +-----------+-----------+
+              |                      |
+              |              +-------v--------+
+              |              | #4 Accounts &   |
+              |              | Cloudron RBAC   |
+              |              +-------+---------+
+              |                      |
+       +------+----------------------+------------------+
+       |                             |                  |
++------v-------+            +--------v--------+         |
+| #6 Public     |<--------- | #5 Editor.js     |         |
+| newsroom/     |  content  | publishing/SEO   |         |
+| discovery     |           | workflow         |         |
++------+--------+           +--------+---------+         |
+       |                             |                   |
+       |                    +--------v---------+         |
+       |                    | #7 Mailing lists, |         |
+       |                    | consent, campaigns|         |
+       |                    +--------+---------+         |
+       |                             |                    |
++------v--------+                    |                    |
+| #8 Profiles,   |                    |                    |
+| comments,      |                    |                    |
+| reactions      |                    |                    |
++------+---------+                    |                    |
+       |                             |                    |
+       +--------------+--------------+--------------------+
+                       |
+              +--------v-------------+
+              | #9 Ghost content/     |
+              | media/redirects       |
+              | import (needs #5,#6)  |
+              +--------+--------------+
+                       |
+       #10 Governance (GDPR/PECR/security/a11y) - runs
        continuously alongside every issue above, formal
-       sign-off gates here before cutover
-                       │
-              ┌────────▼─────────┐
-              │ #11 Validate,     │
-              │ cut over, retire  │
-              │ Ghost (gated)     │
-              └───────────────────┘
+       sign-off gates here before mailing import / cutover
+                       |
+              +--------v-------------+
+              | #18 Ghost mailing CSV |
+              | import (needs #7)     |
+              +--------+--------------+
+                       |
+              +--------v---------+
+              | #11 Validate,     |
+              | cut over, retire  |
+              | Ghost (gated)     |
+              +-------------------+
 ```
 
 ## Phases
@@ -77,22 +82,25 @@ Every sub-issue repeats some version of this, so it's worth stating once: comple
 - **#6 Public newsroom & article discovery.** Depends on #3, #2 (approved page designs), and effectively #5 (needs a post schema to render against, even if seeded with fixtures early). Homepage, channel pages, article/author/search/archive, RSS/sitemap/structured data, redirects, accessibility.
 
 **Phase 3 — Engagement**
-- **#7 Mailing lists, consent, queued campaigns.** Depends on #4 (accounts/contacts) and #5 (the email-this-post flag and approval-time content snapshot live in the publishing workflow). Double opt-in, per-list unsubscribe, consent ledger, Cloudron SMTP queued send, throttling.
+- **#7 Mailing lists, consent, queued campaigns.** Depends on #4 (accounts/contacts) and #5 (the email-this-post flag and approval-time content snapshot live in the publishing workflow). Double opt-in, per-list unsubscribe, consent ledger, Cloudron SMTP queued send, throttling. Runtime mailing product only — Ghost member import is #18.
 - **#8 Moderated profiles, comments, reactions.** Depends on #4 (accounts) and #6 (article pages to attach to). Private-by-default profiles, pre-moderated comments, three toggleable reactions.
 
-**Phase 4 — Migration**
-- **#9 Migrate Ghost posts, media, members, consent, redirects.** Depends on #5 (target content schema), #6 (target slugs/redirects), #7 (target consent/list model) all being stable — this is the last thing to build before governance sign-off and cutover, since it migrates data into the shapes those issues define. Dry-run, resumable, fail-closed on consent, no email from migration runs.
+**Phase 4 — Content import**
+- **#9 Import Ghost posts, media, and redirects from content export.** Depends on #5 (target content schema) and #6 (target slugs/redirects) being stable. File-based import from Ghost content JSON + media archive. Dry-run, resumable/idempotent, no email from import runs. Mailing/members/consent are out of scope (see #18).
 
 **Phase 5 — Governance (continuous + gated)**
-- **#10 GDPR/PECR/security/accessibility governance.** Not a phase that starts after everything else — threat modeling, CSRF/authz/rate-limit controls, CI security checks, and accessibility checks should be built into #3–#9 as they're written. What's specific to #10 is the formal artifact: data inventory, retention schedule, privacy/cookie copy, rights workflows, recorded legal/compliance and accessibility approvals as an explicit launch gate before #11.
+- **#10 GDPR/PECR/security/accessibility governance.** Not a phase that starts after everything else — threat modeling, CSRF/authz/rate-limit controls, CI security checks, and accessibility checks should be built into #3–#9 as they're written. What's specific to #10 is the formal artifact: data inventory, retention schedule, privacy/cookie copy, rights workflows, recorded legal/compliance and accessibility approvals as an explicit launch gate before #18 and #11.
+
+**Phase 5b — Mailing import (pre-cutover)**
+- **#18 Import Ghost mailing lists from members CSV export.** Depends on #7 (target contact/consent/suppression models) and runs after #10 formal gates, immediately before #11. File-based import from Ghost members CSV: mailing contacts (not accounts), fail-closed three-list activation, suppressions, dry-run/resumable/idempotent, reconciliation report, no email from import runs.
 
 **Phase 6 — Cutover**
-- **#11 Validate, cut over apesnews.org.uk, retire Ghost safely.** Depends on everything above. Beta acceptance across every surface, throughput benchmarking, backup/restore/rollback drills, then — only after separate production authorization — the guarded cutover with a defined rollback window. Ghost retirement is a further separate authorization after that window.
+- **#11 Validate, cut over apesnews.org.uk, retire Ghost safely.** Depends on everything above. Beta acceptance across every surface (including separate content and mailing import dry-runs), throughput benchmarking, backup/restore/rollback drills, then — only after separate production authorization — the guarded cutover with final content import then final mailing import from export files, and a defined rollback window. Ghost retirement is a further separate authorization after that window.
 
 ## Open questions worth resolving before/while work starts
 
-Who is doing the #2 design work — is that Bambie/a designer producing wireframes and tokens outside this session, or should I produce a first-pass sitemap/component inventory as a working draft? Access to Cloudron env values, the Cloudron OIDC client, LDAP group names, and the Ghost export/members CSV will be needed before #3's env wiring and #9's migration can be more than scaffolding — presumably held outside this repo. And #10's legal/compliance sign-off needs a named approver — worth confirming who that is early rather than at the #11 gate.
+Who is doing the #2 design work — is that Bambie/a designer producing wireframes and tokens outside this session, or should I produce a first-pass sitemap/component inventory as a working draft? Access to Cloudron env values, the Cloudron OIDC client, LDAP group names, and Ghost Admin exports (content JSON + media archive for #9; members CSV for #18) will be needed before env wiring and import work can be more than scaffolding — no live Ghost API access is required. And #10's legal/compliance sign-off needs a named approver — worth confirming who that is early rather than at the #11 gate.
 
 ## Suggested next step
 
-**Phase 3 (#7 mailing, #8 engagement) is implemented.** Next build focus is **#9 Ghost migration** once mailing/consent and content schemas are accepted as stable enough to import into. Continue polishing #5/#6 residuals (Editor.js UI, archives) in parallel. #10 governance artifacts and #11 cutover remain separately gated.
+**Phase 3 (#7 mailing, #8 engagement) is implemented.** Next build focus is **#9 content/media/redirect import scaffolding** once content schemas (#5/#6) are accepted as stable enough to import into. Continue polishing #5/#6 residuals (Editor.js UI, archives) in parallel. **#18 mailing CSV import comes last before cutover** (after #10). #10 governance artifacts and #11 cutover remain separately gated.


### PR DESCRIPTION
## Summary
- Update the epic build plan so Ghost mailing-list import runs last (after #10, before #11) as new issue #18.
- Reframe #9 as content/media/redirects file-based import from Ghost content JSON; mailing uses members CSV export.

## Test plan
- [ ] Confirm delivery sequence in docs matches #1: #9 → #10 → #18 → #11
- [ ] Spot-check dependency diagram and Phase 5b wording against GitHub issues #9 and #18
