### PR TITLE
feat: local-only role preview for live session switching (#22)

### DIFF
--- a/app/Http/Controllers/Dev/DevLoginController.php
+++ b/app/Http/Controllers/Dev/DevLoginController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers\Dev;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class DevLoginController extends Controller
+{
+    /**
+     * @var array<string, array{email: string, redirect: string}>
+     */
+    private const ROLES = [
+        'public' => [
+            'email' => 'public@apes.local',
+            'redirect' => '/',
+        ],
+        'staff' => [
+            'email' => 'staff@apes.local',
+            'redirect' => '/staff/posts',
+        ],
+        'admin' => [
+            'email' => 'admin@apes.local',
+            'redirect' => '/admin/moderation',
+        ],
+        'super_admin' => [
+            'email' => 'superadmin@apes.local',
+            'redirect' => '/admin/moderation',
+        ],
+    ];
+
+    public function login(Request $request, string $role): RedirectResponse
+    {
+        abort_unless(app()->environment('local'), 404);
+        abort_unless(array_key_exists($role, self::ROLES), 404);
+
+        $user = User::query()
+            ->where('email', self::ROLES[$role]['email'])
+            ->firstOrFail();
+
+        Auth::login($user);
+        $request->session()->regenerate();
+
+        return redirect(self::ROLES[$role]['redirect']);
+    }
+
+    public function logout(Request $request): RedirectResponse
+    {
+        abort_unless(app()->environment('local'), 404);
+
+        Auth::guard('web')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect('/');
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,6 +38,7 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user()?->only(['id', 'name', 'email', 'role']),
             ],
+            'devTools' => app()->environment('local'),
             'flash' => [
                 'status' => fn () => $request->session()->get('status'),
             ],

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -15,11 +14,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            DemoUsersSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DemoUsersSeeder.php
+++ b/database/seeders/DemoUsersSeeder.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\Role;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class DemoUsersSeeder extends Seeder
+{
+    /**
+     * Seed password-based demo users for local role preview.
+     *
+     * All accounts use password "password". Role is force-filled because
+     * it is not mass-assignable on User.
+     */
+    public function run(): void
+    {
+        $users = [
+            [
+                'name' => 'Public Demo',
+                'email' => 'public@apes.local',
+                'role' => Role::Public,
+            ],
+            [
+                'name' => 'Staff Demo',
+                'email' => 'staff@apes.local',
+                'role' => Role::Staff,
+            ],
+            [
+                'name' => 'Admin Demo',
+                'email' => 'admin@apes.local',
+                'role' => Role::Admin,
+            ],
+            [
+                'name' => 'Super Admin Demo',
+                'email' => 'superadmin@apes.local',
+                'role' => Role::SuperAdmin,
+            ],
+        ];
+
+        foreach ($users as $data) {
+            $user = User::query()->updateOrCreate(
+                ['email' => $data['email']],
+                [
+                    'name' => $data['name'],
+                    'password' => 'password',
+                    'email_verified_at' => now(),
+                    'auth_provider' => 'password',
+                ],
+            );
+
+            $user->forceFill(['role' => $data['role']])->save();
+        }
+    }
+}

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -9,13 +9,40 @@ Two modes: **default** (zero extra services) and **production-like**
 composer install
 cp .env.example .env
 php artisan key:generate
-php artisan migrate
+php artisan migrate --seed
 npm install
 composer dev    # or: php artisan serve + npm run dev
 ```
 
 Uses SQLite with database-backed sessions, cache, and queue. No Docker
-required.
+required. Seeding creates password demo users for local role preview
+(see below).
+
+## Role preview (local only)
+
+When `APP_ENV=local`, a floating **Local role preview** bar appears on
+every page. Use it (or the one-click buttons on `/login`) to switch
+sessions without Cloudron OIDC:
+
+| Control | User | Default landing |
+|---------|------|-----------------|
+| Guest | logout | `/` |
+| Public | `public@apes.local` | `/` |
+| Staff | `staff@apes.local` | `/staff/posts` |
+| Admin | `admin@apes.local` | `/admin/moderation` |
+| Super admin | `superadmin@apes.local` | `/admin/moderation` |
+
+Demo password for all seeded users: `password`.
+
+Endpoints (`POST /_dev/login/{role}`, `POST /_dev/logout`) are registered
+only when `APP_ENV=local`, and the controller also returns 404 outside
+local. Do not enable this in staging or production.
+
+```bash
+php artisan migrate --seed
+composer dev
+# open http://localhost:8000 — use the floating switcher
+```
 
 ## Production-like setup
 

--- a/resources/js/Components/Dev/RoleSwitcher.tsx
+++ b/resources/js/Components/Dev/RoleSwitcher.tsx
@@ -1,0 +1,76 @@
+import { router, usePage } from '@inertiajs/react';
+
+type AuthUser = {
+    id: number;
+    name: string;
+    email: string;
+    role: string;
+} | null;
+
+const ROLES = [
+    { key: 'guest', label: 'Guest' },
+    { key: 'public', label: 'Public' },
+    { key: 'staff', label: 'Staff' },
+    { key: 'admin', label: 'Admin' },
+    { key: 'super_admin', label: 'Super admin' },
+] as const;
+
+export default function RoleSwitcher() {
+    const { auth, devTools } = usePage<{
+        auth: { user: AuthUser };
+        devTools?: boolean;
+    }>().props;
+
+    if (!devTools) {
+        return null;
+    }
+
+    const current = auth.user?.role ?? 'guest';
+
+    const switchTo = (key: (typeof ROLES)[number]['key']) => {
+        if (key === 'guest') {
+            router.post('/_dev/logout');
+            return;
+        }
+
+        router.post(`/_dev/login/${key}`);
+    };
+
+    return (
+        <div
+            className="fixed inset-x-0 bottom-0 z-[9999] border-t border-amber-700/40 bg-amber-50/95 px-3 py-2 text-amber-950 shadow-[0_-4px_16px_rgba(0,0,0,0.08)] backdrop-blur-sm"
+            role="region"
+            aria-label="Local role preview"
+        >
+            <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-amber-800">
+                    Local role preview
+                    <span className="ml-2 font-normal normal-case tracking-normal text-amber-700">
+                        {auth.user ? `${auth.user.name} (${auth.user.role})` : 'Guest'}
+                    </span>
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                    {ROLES.map((role) => {
+                        const active = current === role.key;
+
+                        return (
+                            <button
+                                key={role.key}
+                                type="button"
+                                onClick={() => switchTo(role.key)}
+                                disabled={active}
+                                className={
+                                    active
+                                        ? 'rounded bg-amber-800 px-2.5 py-1 text-xs font-medium text-white'
+                                        : 'rounded border border-amber-700/30 bg-white px-2.5 py-1 text-xs font-medium text-amber-950 hover:bg-amber-100'
+                                }
+                            >
+                                {role.label}
+                            </button>
+                        );
+                    })}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/Pages/Auth/Login.tsx
+++ b/resources/js/Pages/Auth/Login.tsx
@@ -1,4 +1,4 @@
-import { Head, Link, useForm } from '@inertiajs/react';
+import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
 
 interface LoginProps {
@@ -6,7 +6,15 @@ interface LoginProps {
     staffLoginLabel: string | null;
 }
 
+const DEV_ROLES = [
+    { key: 'public', label: 'Public' },
+    { key: 'staff', label: 'Staff' },
+    { key: 'admin', label: 'Admin' },
+    { key: 'super_admin', label: 'Super admin' },
+] as const;
+
 export default function Login({ staffLoginUrl, staffLoginLabel }: LoginProps) {
+    const { devTools } = usePage<{ devTools?: boolean }>().props;
     const { data, setData, post, processing, errors, reset } = useForm({
         email: '',
         password: '',
@@ -34,6 +42,23 @@ export default function Login({ staffLoginUrl, staffLoginLabel }: LoginProps) {
                             {staffLoginLabel ?? 'Staff sign in'}
                         </a>
                         <p className="text-center text-xs text-neutral-500">or use a public account below</p>
+                    </div>
+                )}
+                {devTools && (
+                    <div className="flex flex-col gap-2 rounded border border-amber-300 bg-amber-50 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-amber-800">Local role preview</p>
+                        <div className="flex flex-wrap gap-1.5">
+                            {DEV_ROLES.map((role) => (
+                                <button
+                                    key={role.key}
+                                    type="button"
+                                    onClick={() => router.post(`/_dev/login/${role.key}`)}
+                                    className="rounded border border-amber-700/30 bg-white px-2.5 py-1 text-xs font-medium text-amber-950 hover:bg-amber-100"
+                                >
+                                    {role.label}
+                                </button>
+                            ))}
+                        </div>
                     </div>
                 )}
                 <form onSubmit={submit} className="flex flex-col gap-4">

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -2,6 +2,7 @@ import '../css/app.css';
 
 import { createInertiaApp } from '@inertiajs/react';
 import { createRoot } from 'react-dom/client';
+import RoleSwitcher from './Components/Dev/RoleSwitcher';
 
 const appName = document.title || 'APES Newsroom';
 
@@ -18,6 +19,15 @@ createInertiaApp({
         return page;
     },
     setup({ el, App, props }) {
-        createRoot(el).render(<App {...props} />);
+        createRoot(el).render(
+            <App {...props}>
+                {({ Component, props: pageProps, key }) => (
+                    <>
+                        <Component key={key} {...pageProps} />
+                        <RoleSwitcher />
+                    </>
+                )}
+            </App>,
+        );
     },
 });

--- a/routes/dev.php
+++ b/routes/dev.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Http\Controllers\Dev\DevLoginController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Local-only development routes
+|--------------------------------------------------------------------------
+|
+| Registered from web.php only when APP_ENV=local. Controllers also
+| abort_unless local as a second gate.
+|
+*/
+
+Route::post('/_dev/login/{role}', [DevLoginController::class, 'login'])
+    ->where('role', 'public|staff|admin|super_admin')
+    ->name('dev.login');
+
+Route::post('/_dev/logout', [DevLoginController::class, 'logout'])
+    ->name('dev.logout');

--- a/routes/web.php
+++ b/routes/web.php
@@ -115,3 +115,7 @@ Route::middleware(['auth', 'verified', 'role:'.Role::Staff->value])
     });
 
 require __DIR__.'/auth.php';
+
+if (app()->environment('local')) {
+    require __DIR__.'/dev.php';
+}

--- a/tests/Feature/Dev/DevLoginTest.php
+++ b/tests/Feature/Dev/DevLoginTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Dev;
+
+use App\Enums\Role;
+use Database\Seeders\DemoUsersSeeder;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class DevLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dev_login_routes_are_unavailable_when_not_local(): void
+    {
+        $this->assertFalse(app()->environment('local'));
+
+        $this->post('/_dev/login/public')->assertNotFound();
+        $this->post('/_dev/logout')->assertNotFound();
+    }
+
+    public function test_dev_login_controller_aborts_outside_local_even_if_routed(): void
+    {
+        $this->assertFalse(app()->environment('local'));
+
+        Route::middleware('web')->group(base_path('routes/dev.php'));
+
+        $this->post('/_dev/login/public')->assertNotFound();
+        $this->post('/_dev/logout')->assertNotFound();
+    }
+
+    public function test_each_role_can_authenticate_and_reach_expected_surfaces(): void
+    {
+        $this->enableLocalDevRoutes();
+        $this->seed(DemoUsersSeeder::class);
+
+        $cases = [
+            'public' => [
+                'role' => Role::Public,
+                'redirect' => '/',
+                'allowed' => ['/'],
+                'forbidden' => ['/staff/posts', '/admin/moderation'],
+            ],
+            'staff' => [
+                'role' => Role::Staff,
+                'redirect' => '/staff/posts',
+                'allowed' => ['/staff/posts'],
+                'forbidden' => ['/admin/moderation'],
+            ],
+            'admin' => [
+                'role' => Role::Admin,
+                'redirect' => '/admin/moderation',
+                'allowed' => ['/staff/posts', '/admin/moderation'],
+                'forbidden' => [],
+            ],
+            'super_admin' => [
+                'role' => Role::SuperAdmin,
+                'redirect' => '/admin/moderation',
+                'allowed' => ['/staff/posts', '/admin/moderation'],
+                'forbidden' => [],
+            ],
+        ];
+
+        foreach ($cases as $roleKey => $case) {
+            Auth::logout();
+
+            $this->post("/_dev/login/{$roleKey}")
+                ->assertRedirect($case['redirect']);
+
+            $this->assertAuthenticated();
+            $this->assertSame($case['role'], Auth::user()->role);
+
+            foreach ($case['allowed'] as $path) {
+                $this->get($path)->assertOk();
+            }
+
+            foreach ($case['forbidden'] as $path) {
+                $this->get($path)->assertForbidden();
+            }
+        }
+    }
+
+    public function test_guest_logout_clears_the_session(): void
+    {
+        $this->enableLocalDevRoutes();
+        $this->seed(DemoUsersSeeder::class);
+
+        $this->post('/_dev/login/staff')->assertRedirect('/staff/posts');
+        $this->assertAuthenticated();
+
+        $this->post('/_dev/logout')->assertRedirect('/');
+        $this->assertGuest();
+    }
+
+    public function test_unknown_role_returns_not_found(): void
+    {
+        $this->enableLocalDevRoutes();
+
+        $this->post('/_dev/login/not-a-role')->assertNotFound();
+    }
+
+    public function test_inertia_shares_dev_tools_only_in_local(): void
+    {
+        $this->get('/')->assertInertia(fn ($page) => $page
+            ->where('devTools', false));
+
+        $this->app['env'] = 'local';
+
+        $this->get('/')->assertInertia(fn ($page) => $page
+            ->where('devTools', true));
+    }
+
+    private function enableLocalDevRoutes(): void
+    {
+        // Switching env to local disables Laravel's unit-test CSRF bypass
+        // (runningUnitTests checks APP_ENV === testing).
+        $this->app['env'] = 'local';
+        $this->withoutMiddleware(PreventRequestForgery::class);
+
+        Route::middleware('web')->group(base_path('routes/dev.php'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add local-only `/_dev` login/logout and floating RoleSwitcher so Guest / Public / Staff / Admin / Super admin can be switched without Cloudron OIDC
- Seed password demo users (`*@apes.local` / `password`) and gate routes + controller on `APP_ENV=local`
- Document the workflow in `docs/local-dev.md`; cover with `DevLoginTest`

Closes engineering AC for #22 once merged (local preview only; no production impact).

## Test plan
- [ ] `composer test` / `composer lint` / `npm run typecheck`
- [ ] `php artisan migrate --seed` then `composer dev`
- [ ] Confirm RoleSwitcher appears only when `APP_ENV=local`
- [ ] Switch Guest → Public → Staff → Admin → Super admin and verify landings/access
- [ ] Confirm `/_dev/*` returns 404 when `APP_ENV` is not `local`