### PR TITLE
fix: preserve CLOUDRON_* for www-data artisan (#3)

### DIFF
--- a/deploy/cloudron-activate.sh
+++ b/deploy/cloudron-activate.sh
@@ -71,21 +71,35 @@ chown www-data:www-data /run/php/sessions
 
 chown -R www-data:www-data "${RELEASE_DIR}"
 
+WWW_DATA_PHP=(bash "${RELEASE_DIR}/deploy/cloudron-www-data.sh" /usr/bin/php)
+
 if [ -f "${CURRENT_LINK}" ] || [ -L "${CURRENT_LINK}" ]; then
     readlink "${CURRENT_LINK}" > "${PREVIOUS_FILE}" || true
 fi
 
 echo "==> Generating APP_KEY if this is a first-ever deploy"
-sudo -u www-data php "${RELEASE_DIR}/artisan" key:generate --force --no-interaction \
+"${WWW_DATA_PHP[@]}" "${RELEASE_DIR}/artisan" key:generate --force --no-interaction \
     --ansi 2>&1 | grep -v 'Application key set' || true
 
+# Fail closed: if Cloudron MySQL is provisioned, www-data artisan must see
+# mysql — otherwise migrate would write to sqlite and leave MySQL empty.
+if [ -n "${CLOUDRON_MYSQL_HOST:-}" ]; then
+    echo "==> Asserting www-data artisan targets MySQL (not sqlite fallback)"
+    db_default="$("${WWW_DATA_PHP[@]}" "${RELEASE_DIR}/artisan" tinker --execute="echo config('database.default');")"
+    if [ "${db_default}" != "mysql" ]; then
+        echo "FATAL: CLOUDRON_MYSQL_HOST is set but artisan database.default is '${db_default:-empty}' (expected mysql)." >&2
+        echo "sudo likely stripped CLOUDRON_* — use deploy/cloudron-www-data.sh." >&2
+        exit 1
+    fi
+fi
+
 echo "==> Running database migrations"
-sudo -u www-data php "${RELEASE_DIR}/artisan" migrate --force --no-interaction
+"${WWW_DATA_PHP[@]}" "${RELEASE_DIR}/artisan" migrate --force --no-interaction
 
 echo "==> Caching config/routes/views for the new release"
-sudo -u www-data php "${RELEASE_DIR}/artisan" config:cache
-sudo -u www-data php "${RELEASE_DIR}/artisan" route:cache
-sudo -u www-data php "${RELEASE_DIR}/artisan" view:cache
+"${WWW_DATA_PHP[@]}" "${RELEASE_DIR}/artisan" config:cache
+"${WWW_DATA_PHP[@]}" "${RELEASE_DIR}/artisan" route:cache
+"${WWW_DATA_PHP[@]}" "${RELEASE_DIR}/artisan" view:cache
 
 echo "==> Activating release ${RELEASE_SHA} atomically"
 ln -sfn "${RELEASE_DIR}" "${CURRENT_LINK}.new"

--- a/deploy/cloudron-rollback.sh
+++ b/deploy/cloudron-rollback.sh
@@ -27,9 +27,10 @@ if [ ! -d "${PREVIOUS_RELEASE_DIR}" ]; then
 fi
 
 echo "==> Rolling back to ${PREVIOUS_RELEASE_DIR}"
-sudo -u www-data php "${PREVIOUS_RELEASE_DIR}/artisan" config:cache
-sudo -u www-data php "${PREVIOUS_RELEASE_DIR}/artisan" route:cache
-sudo -u www-data php "${PREVIOUS_RELEASE_DIR}/artisan" view:cache
+WWW_DATA_PHP=(bash "${PREVIOUS_RELEASE_DIR}/deploy/cloudron-www-data.sh" /usr/bin/php)
+"${WWW_DATA_PHP[@]}" "${PREVIOUS_RELEASE_DIR}/artisan" config:cache
+"${WWW_DATA_PHP[@]}" "${PREVIOUS_RELEASE_DIR}/artisan" route:cache
+"${WWW_DATA_PHP[@]}" "${PREVIOUS_RELEASE_DIR}/artisan" view:cache
 
 ln -sfn "${PREVIOUS_RELEASE_DIR}" "${CURRENT_LINK}.new"
 mv -Tf "${CURRENT_LINK}.new" "${CURRENT_LINK}"

--- a/deploy/cloudron-run.sh
+++ b/deploy/cloudron-run.sh
@@ -20,7 +20,9 @@ chown www-data:www-data /run/php/sessions
 
 if [ -L /app/data/current ]; then
     echo "Starting queue worker against $(readlink /app/data/current)"
-    sudo -u www-data /usr/bin/php /app/data/current/artisan queue:work \
+    # Preserve CLOUDRON_* so the worker uses MySQL/Redis/SMTP, not .env sqlite.
+    bash /app/data/current/deploy/cloudron-www-data.sh \
+        /usr/bin/php /app/data/current/artisan queue:work \
         --queue=default --sleep=3 --tries=3 --max-time=3600 &
 else
     echo "No /app/data/current release yet - skipping queue worker start."

--- a/deploy/cloudron-www-data.sh
+++ b/deploy/cloudron-www-data.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run a command as www-data while preserving Cloudron addon environment
+# variables (CLOUDRON_*).
+#
+# Plain `sudo -u www-data` resets the environment. Without CLOUDRON_MYSQL_*,
+# CloudronEnvironmentServiceProvider leaves DB_CONNECTION=sqlite from the
+# shared .env, so artisan migrate/queue/schedule silently target SQLite while
+# Apache/php-fpm (which still has CLOUDRON_*) serves MySQL. That mismatch
+# caused beta homepage 500s after a "successful" migrate (#3).
+#
+# Usage (from activate/rollback/run/cron):
+#   bash /app/data/current/deploy/cloudron-www-data.sh \
+#     /usr/bin/php /app/data/current/artisan migrate --force
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: cloudron-www-data.sh <command> [args...]" >&2
+    exit 1
+fi
+
+preserve=()
+while IFS= read -r line; do
+    preserve+=("$line")
+done < <(env | grep '^CLOUDRON_' || true)
+
+if [ "${#preserve[@]}" -eq 0 ]; then
+    echo "warning: no CLOUDRON_* vars in this shell; artisan may fall back to .env sqlite" >&2
+fi
+
+exec sudo -u www-data env "${preserve[@]}" "$@"

--- a/docs/deployment-beta-acceptance.md
+++ b/docs/deployment-beta-acceptance.md
@@ -17,8 +17,10 @@ Record evidence (screenshots, command output, timestamps) in issue #3 comments.
 - [ ] Trigger "Deploy to Cloudron (beta)" workflow manually from `main`
 - [ ] Cloudron backup created successfully before activation
 - [ ] Migrations run without error
+- [ ] Activate log shows MySQL assert (`www-data artisan targets MySQL`) — not silent sqlite
 - [ ] Health check passes within 60 seconds
 - [ ] Workflow reports success
+- [ ] Homepage `/` returns 200 (not only `/health` / `/login`)
 
 ## Post-deploy verification
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -66,7 +66,11 @@ These happen once, outside of CI, before the first deploy can work.
 5. **Add the scheduler cron entry.** In the Cloudron dashboard, this
    app's `Cron` section, add:
    - Schedule: `* * * * *`
-   - Command: `sudo -u www-data /usr/bin/php /app/data/current/artisan schedule:run`
+   - Command: `bash /app/data/current/deploy/cloudron-www-data.sh /usr/bin/php /app/data/current/artisan schedule:run`
+
+   Do **not** use bare `sudo -u www-data php …` — that strips `CLOUDRON_*`
+   and artisan falls back to sqlite from the shared `.env` while the web
+   app still uses MySQL. See `deploy/cloudron-www-data.sh`.
 
    (Cloudron's per-app Cron feature, not a crontab file - see
    docs.cloudron.io/apps#cron.)
@@ -168,6 +172,28 @@ Expected: `"cache": true` in the health response.
 
 Ensure `/app/data/run.sh` exists (copy from `deploy/cloudron-run.sh`) so
 the queue worker starts on boot against the Redis-backed queue.
+
+## Artisan must preserve CLOUDRON_* (www-data)
+
+Cloudron injects `CLOUDRON_MYSQL_*` / `CLOUDRON_REDIS_*` / SMTP vars into
+the container environment. Apache/php-fpm sees them, so the web app uses
+MySQL. Bare `sudo -u www-data …` **strips** those variables, so artisan
+falls back to `DB_CONNECTION=sqlite` from the shared `.env` and can
+silently migrate the wrong database.
+
+Always run artisan as www-data via:
+
+```bash
+bash /app/data/current/deploy/cloudron-www-data.sh \
+  /usr/bin/php /app/data/current/artisan <command>
+```
+
+`cloudron-activate.sh`, `cloudron-rollback.sh`, and `cloudron-run.sh` use
+this helper. Scheduler cron must use it too (see one-time setup above).
+
+**Symptom of the bug:** `/health` and `/login` OK; `/` and discovery routes
+500 with `Table '….posts' doesn't exist` on MySQL while `migrate:status`
+under `sudo -u www-data` looks clean against sqlite.
 
 ## OIDC client (staff sign-in)
 


### PR DESCRIPTION
## Summary
- Root cause of beta homepage 500: `sudo -u www-data` stripped `CLOUDRON_*`, so `artisan migrate` wrote to sqlite while Apache served MySQL (`posts` missing).
- Add `deploy/cloudron-www-data.sh` and use it from activate/rollback/run + document cron.
- Activate now asserts MySQL before migrate when `CLOUDRON_MYSQL_HOST` is set.
- Hotfixed beta MySQL migrations in place; `/` already returns 200.

## Test plan
- [ ] Merge and run guarded beta deploy from `main`
- [ ] Activate log shows MySQL assert + migrate on MySQL
- [ ] `/`, `/apes-cic`, `/search?q=…`, `/rss.xml`, `/sitemap.xml` return 200
- [ ] Rollback drill per `docs/deployment-beta-acceptance.md`
- [ ] Confirm cron uses `cloudron-www-data.sh` wrapper

Relates to #3