### PR TITLE
fix: Cloudron OIDC/LDAP live staff auth for beta (#4)

### DIFF
--- a/app/Console/Commands/ReconcileStaffRolesCommand.php
+++ b/app/Console/Commands/ReconcileStaffRolesCommand.php
@@ -43,8 +43,16 @@ class ReconcileStaffRolesCommand extends Command
             }
 
             $matchedRoles = collect($groups)
-                ->map(fn (string $group) => $map->get(mb_strtolower($group)))
+                ->flatMap(function (string $group) use ($map) {
+                    $keys = [mb_strtolower($group)];
+                    if (preg_match('/(^|,)cn=([^,]+)/i', $group, $matches) === 1) {
+                        $keys[] = mb_strtolower($matches[2]);
+                    }
+
+                    return collect($keys)->map(fn (string $key) => $map->get($key));
+                })
                 ->filter()
+                ->unique()
                 ->values();
 
             if ($matchedRoles->isEmpty()) {

--- a/app/Providers/CloudronEnvironmentServiceProvider.php
+++ b/app/Providers/CloudronEnvironmentServiceProvider.php
@@ -138,11 +138,22 @@ class CloudronEnvironmentServiceProvider extends ServiceProvider
             return;
         }
 
-        Config::set('ldap.connections.default.hosts', [$this->cloudronEnv('CLOUDRON_LDAP_URL')]);
+        $ldapUrl = (string) $this->cloudronEnv('CLOUDRON_LDAP_URL');
+        $parsed = parse_url($ldapUrl);
+        $host = $this->cloudronEnv('CLOUDRON_LDAP_HOST')
+            ?: ($parsed['host'] ?? null);
+        $port = $this->cloudronEnv('CLOUDRON_LDAP_PORT')
+            ?: ($parsed['port'] ?? 389);
+
+        if ($host) {
+            Config::set('ldap.connections.default.hosts', [(string) $host]);
+        }
+
+        Config::set('ldap.connections.default.port', (int) $port);
         Config::set('ldap.connections.default.username', $this->cloudronEnv('CLOUDRON_LDAP_BIND_DN'));
         Config::set('ldap.connections.default.password', $this->cloudronEnv('CLOUDRON_LDAP_BIND_PASSWORD'));
         Config::set('ldap.connections.default.base_dn', $this->cloudronEnv('CLOUDRON_LDAP_USERS_BASE_DN'));
-        Config::set('services.cloudron_ldap.url', $this->cloudronEnv('CLOUDRON_LDAP_URL'));
+        Config::set('services.cloudron_ldap.url', $ldapUrl);
         Config::set('services.cloudron_ldap.users_base_dn', $this->cloudronEnv('CLOUDRON_LDAP_USERS_BASE_DN'));
         Config::set('services.cloudron_ldap.groups_base_dn', $this->cloudronEnv('CLOUDRON_LDAP_GROUPS_BASE_DN'));
         Config::set('services.cloudron_ldap.bind_dn', $this->cloudronEnv('CLOUDRON_LDAP_BIND_DN'));

--- a/app/Services/Auth/CloudronOidcProvider.php
+++ b/app/Services/Auth/CloudronOidcProvider.php
@@ -56,6 +56,8 @@ class CloudronOidcProvider
             'urlAuthorize' => $discovery['authorization_endpoint'],
             'urlAccessToken' => $discovery['token_endpoint'],
             'urlResourceOwnerDetails' => $discovery['userinfo_endpoint'],
+            // OIDC requires space-delimited scopes; league/oauth2-client defaults to commas.
+            'scopeSeparator' => ' ',
         ]);
     }
 

--- a/app/Services/Auth/LdapGroupLookup.php
+++ b/app/Services/Auth/LdapGroupLookup.php
@@ -52,6 +52,10 @@ class LdapGroupLookup
             return $memberof !== '' && $memberof !== null ? [(string) $memberof] : [];
         }
 
-        return array_values(array_map('strval', $memberof));
+        // LdapRecord/php-ldap may include a numeric `count` entry alongside DNs.
+        return array_values(array_filter(
+            array_map('strval', $memberof),
+            fn (string $value) => $value !== '' && ! ctype_digit($value),
+        ));
     }
 }

--- a/app/Services/Auth/StaffReconciler.php
+++ b/app/Services/Auth/StaffReconciler.php
@@ -38,9 +38,16 @@ class StaffReconciler
 
         $role = collect($matchedRoles)->sortByDesc(fn (Role $role) => $role->rank())->first();
 
-        $user = User::firstOrNew(['external_id' => $identity->sub]);
+        $user = User::query()
+            ->where('external_id', $identity->sub)
+            ->orWhere(function ($query) use ($identity): void {
+                $query->where('email', $identity->email)
+                    ->where('auth_provider', 'cloudron_oidc');
+            })
+            ->first() ?? new User;
 
         $user->forceFill([
+            'external_id' => $identity->sub,
             'name' => $identity->name,
             'email' => $identity->email,
             'email_verified_at' => now(),
@@ -60,12 +67,35 @@ class StaffReconciler
     private function matchRoles(array $groups): array
     {
         $map = collect(config('rbac.ldap_group_map', []))
-            ->mapWithKeys(fn (Role $role, string $dn) => [mb_strtolower($dn) => $role]);
+            ->mapWithKeys(fn (Role $role, string $key) => [mb_strtolower($key) => $role]);
 
         return collect($groups)
-            ->map(fn (string $group) => $map->get(mb_strtolower($group)))
+            ->flatMap(fn (string $group) => $this->groupLookupKeys($group))
+            ->map(fn (string $key) => $map->get($key))
             ->filter()
+            ->unique()
             ->values()
             ->all();
+    }
+
+    /**
+     * Build case-insensitive lookup keys for a memberof value.
+     *
+     * Cloudron returns full DNs (`cn=newsroom.staff,ou=groups,dc=cloudron`);
+     * local OpenLDAP tests often pass bare CNs. Match both the raw value
+     * and the CN RDN when present.
+     *
+     * @return array<int, string>
+     */
+    private function groupLookupKeys(string $group): array
+    {
+        $normalized = mb_strtolower($group);
+        $keys = [$normalized];
+
+        if (preg_match('/(^|,)cn=([^,]+)/i', $group, $matches) === 1) {
+            $keys[] = mb_strtolower($matches[2]);
+        }
+
+        return array_values(array_unique($keys));
     }
 }

--- a/config/rbac.php
+++ b/config/rbac.php
@@ -15,17 +15,21 @@ return [
     | in docs/deployment.md to discover the real group names after
     | creating groups in Cloudron.
     |
-    | Cloudron may return either a group CN (e.g. `newsroom-staff`) or a
-    | full DN — include whichever format your directory returns. Only
-    | groups listed here are recognised. Any staff member whose groups do
-    | not intersect this map is denied login (fail closed) — see
-    | App\Services\Auth\StaffReconciler.
+    | Cloudron may return a full DN (`cn=newsroom.staff,ou=groups,dc=cloudron`).
+    | StaffReconciler also matches the CN RDN extracted from a DN, so map
+    | keys can be CNs. Include local OpenLDAP hyphenated CNs and the live
+    | Cloudron dotted group names used on the directory.
     |
     */
     'ldap_group_map' => [
+        // Local OpenLDAP (docker/openldap/bootstrap.ldif)
         'newsroom-staff' => Role::Staff,
         'newsroom-admins' => Role::Admin,
         'newsroom-super-admins' => Role::SuperAdmin,
+        // Live Cloudron groups (memberof CNs)
+        'newsroom.staff' => Role::Staff,
+        'newsroom.admin' => Role::Admin,
+        'newsroom.superadmin' => Role::SuperAdmin,
     ],
 
 ];

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -226,7 +226,10 @@ For local development, create a **second** client with redirect URI
 ## LDAP group mapping
 
 Staff roles are derived from each user's `memberof` attribute in Cloudron
-LDAP. Group names must match keys in `config/rbac.php`.
+LDAP. Live Cloudron groups are `newsroom.staff`, `newsroom.admin`, and
+`newsroom.superadmin` (mapped in `config/rbac.php`). `memberof` returns
+full DNs such as `cn=newsroom.staff,ou=groups,dc=cloudron`; the reconciler
+matches the CN RDN as well as bare CNs used in local OpenLDAP.
 
 **Discover group names** inside the Cloudron container:
 
@@ -242,8 +245,10 @@ cloudron exec --app 74a2a784-a161-4787-84ff-2b8efc957bc8 -- bash -c \
   'ldapsearch -x -H "$CLOUDRON_LDAP_URL" -D "$CLOUDRON_LDAP_BIND_DN" -w "$CLOUDRON_LDAP_BIND_PASSWORD" -b "$CLOUDRON_LDAP_USERS_BASE_DN" "(mail=<user-email>)" memberof'
 ```
 
-Update `config/rbac.php` so keys match the `memberof` values exactly
-(case-insensitive). Deploy the updated config to beta.
+OIDC credentials for LAMP apps are not auto-injected. Prefer
+`cloudron env set` for `CLOUDRON_OIDC_*` so `CloudronEnvironmentServiceProvider`
+(which reads `getenv`) sees them after `config:cache`. Also keep the same
+keys in `/app/data/shared/.env` if you maintain that file by hand.
 
 ## End-to-end verification (beta)
 

--- a/tests/Feature/Auth/StaffOidcLoginTest.php
+++ b/tests/Feature/Auth/StaffOidcLoginTest.php
@@ -130,4 +130,41 @@ class StaffOidcLoginTest extends TestCase
 
         $this->assertNull($result->user->password);
     }
+
+    public function test_cloudron_memberof_dn_matches_dotted_group_cn(): void
+    {
+        $result = $this->reconcilerWithGroups([
+            'cn=newsroom.superadmin,ou=groups,dc=cloudron',
+        ])->reconcile($this->identity());
+
+        $this->assertTrue($result->allowed);
+        $this->assertSame(Role::SuperAdmin, $result->user->role);
+    }
+
+    public function test_cloudron_admin_memberof_dn_grants_admin(): void
+    {
+        $result = $this->reconcilerWithGroups([
+            'cn=newsroom.admin,ou=groups,dc=cloudron',
+        ])->reconcile($this->identity());
+
+        $this->assertTrue($result->allowed);
+        $this->assertSame(Role::Admin, $result->user->role);
+    }
+
+    public function test_existing_cloudron_user_is_relinked_when_oidc_sub_changes(): void
+    {
+        $existing = User::factory()->staff()->create([
+            'email' => 'staffer@example.com',
+            'external_id' => 'old-sub',
+            'auth_provider' => 'cloudron_oidc',
+        ]);
+
+        $result = $this->reconcilerWithGroups([self::STAFF_GROUP])
+            ->reconcile(new StaffOidcIdentity(sub: 'new-sub', email: 'staffer@example.com', name: 'Staffer Person'));
+
+        $this->assertTrue($result->allowed);
+        $this->assertSame($existing->id, $result->user->id);
+        $this->assertSame('new-sub', $result->user->fresh()->external_id);
+        $this->assertSame(1, User::count());
+    }
 }


### PR DESCRIPTION
## Summary
- Align `config/rbac.php` with live Cloudron groups (`newsroom.staff` / `newsroom.admin` / `newsroom.superadmin`) while keeping local hyphenated OpenLDAP names.
- Parse `CLOUDRON_LDAP_HOST`/`PORT` (or URL) for LdapRecord instead of treating the full LDAP URL as a hostname.
- Use space-delimited OIDC scopes so Cloudron returns an authorization code.
- Match `memberof` DNs by CN RDN; filter LDAP count artifacts; relink staff users when OIDC `sub` changes; apply the same matching in `staff:reconcile-roles`.

## Test plan
- [x] `StaffOidcLoginTest` + `LdapGroupLookupTest` pass locally
- [x] Live beta: staff CTA on `/login`, OIDC login grants `staff`, staff posts accessible
- [x] Live beta: group removal + `staff:reconcile-roles` demotes; LDAP down fails closed while public `/` stays 200

Closes #4