### PR TITLE
feat: Friendly Guide UI and Account-menu Admin link (#27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .phpunit.result.cache
 /.codex
 /.cursor/
+/.superpowers/
 /.idea
 /.nova
 /.phpunit.cache

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Enums\Role;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -37,6 +38,10 @@ class HandleInertiaRequests extends Middleware
             'appName' => config('app.name'),
             'auth' => [
                 'user' => $request->user()?->only(['id', 'name', 'email', 'role']),
+                'can' => [
+                    'accessStaff' => $request->user()?->role->atLeast(Role::Staff) ?? false,
+                    'accessAdmin' => $request->user()?->role->atLeast(Role::Admin) ?? false,
+                ],
             ],
             'devTools' => app()->environment('local'),
             'flash' => [

--- a/docs/design/component-inventory.md
+++ b/docs/design/component-inventory.md
@@ -1,14 +1,19 @@
 # APES Newsroom — Component Inventory (draft)
 
-> **Status:** First-pass draft for stakeholder review (#2).
+> **Status:** Updated for Friendly Guide UI (#27). Baseline from #2; public chrome now follows
+> [`docs/superpowers/specs/2026-08-06-friendly-guide-ui-design.md`](../superpowers/specs/2026-08-06-friendly-guide-ui-design.md).
 
 ## Layout
 
 | Component | Description | States |
 |-----------|-------------|--------|
-| `SiteHeader` | Logo, primary nav, search, account | default, mobile menu open |
-| `SiteFooter` | Links, charity info, privacy | default |
-| `SkipLink` | Skip to main content | focus visible |
+| `PublicLayout` | Skip link, brand header, Search, AccountMenu, page tint, footer | guest, signed-in |
+| `AccountMenu` | Login/Register or You disclosure with Profile / Admin / Staff / Sign out | guest, public, staff, admin |
+| `SiteFooter` | Privacy, cookies, rights, mailing | default |
+| `ChannelTrailTile` | Channel trail with icon, hint, accent border, chunky shadow | default, focus |
+| `DeskPanel` | “On the desk” featured + recent stack | empty, with featured |
+| `SiteHeader` | (legacy name) superseded by `PublicLayout` header | — |
+| `SkipLink` | Skip to main content (in `PublicLayout`) | focus visible |
 | `PageContainer` | Max-width wrapper with gutters | — |
 | `ChannelHero` | Channel landing hero with accent | default |
 

--- a/docs/design/tokens.md
+++ b/docs/design/tokens.md
@@ -15,11 +15,24 @@ Mission-led editorial: authentic animal-care imagery, warm APES accents, high-co
 | `--color-clinic-accent` | `#457B9D` | Pet Care Clinic channel |
 | `--color-neutral-900` | `#1A1A1A` | Headings, body text |
 | `--color-neutral-600` | `#525252` | Secondary text |
-| `--color-neutral-100` | `#F5F5F4` | Page backgrounds |
+| `--color-neutral-100` | `#F5F5F4` | Quiet secondary surfaces |
+| `--color-page-tint` | `#F7FBF9` | Public page backgrounds (Friendly Guide) |
 | `--color-surface` | `#FFFFFF` | Cards, panels |
 | `--color-error` | `#B91C1C` | Errors, destructive actions |
 | `--color-success` | `#15803D` | Success states |
 | `--color-focus` | `#2563EB` | Focus rings |
+
+## Friendly Guide surfaces
+
+| Token / class | Value | Usage |
+|---------------|-------|-------|
+| `--radius-tile` | `1rem` | Trail tiles and desk panel corners |
+| `.shadow-chunky-apes` | `4px 4px 0` primary | APES CIC trail tiles |
+| `.shadow-chunky-shelter` | `4px 4px 0` shelter accent | Shelter trail tiles |
+| `.shadow-chunky-clinic` | `4px 4px 0` clinic accent | Clinic trail tiles |
+| `.shadow-chunky-ink` | `4px 4px 0` neutral-900 | Desk panel and menus |
+
+Chunky shadows are for trail tiles, desk panels, and Account menu only — not article body.
 
 ## Typography
 

--- a/docs/superpowers/plans/2026-08-06-friendly-guide-ui.md
+++ b/docs/superpowers/plans/2026-08-06-friendly-guide-ui.md
@@ -1,0 +1,762 @@
+# Friendly Guide UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the approved Friendly Guide public chrome, split-desk homepage, and role-gated Account-menu Admin/Staff links (#27).
+
+**Architecture:** Add shared Inertia auth capability flags; introduce a `PublicLayout` (header + AccountMenu + footer) and homepage desk/trail components; restyle tokens in Tailwind v4 `@theme`. Keep article long-form calm. Admin hub defaults to `/admin/moderation`; Staff desk to `/staff/posts`. Channel icons are emoji placeholders keyed by slug.
+
+**Tech Stack:** Laravel 13, Inertia React, Tailwind CSS v4, PHPUnit feature tests, TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-08-06-friendly-guide-ui-design.md`  
+**Issue:** #27  
+**Branch:** `cursor/feature/27-friendly-guide-ui`
+
+## Global Constraints
+
+- Personality: Friendly Guide only (trail tiles, chunky offset shadows) — no purple gradients, cream+terracotta kitsch, or broadsheet hairlines.
+- Colours: keep `--color-apes-primary` `#2D6A4F`, `--color-shelter-accent` `#BC6C25`, `--color-clinic-accent` `#457B9D`.
+- Admin entry: Account menu only; never a persistent public header Admin button.
+- Admin hub URL: `/admin/moderation`. Staff desk URL: `/staff/posts`.
+- Show Admin menu item only when `auth.can.accessAdmin`; Staff when `auth.can.accessStaff`.
+- Never show Admin/Staff links to `public`-only users.
+- Honour `prefers-reduced-motion` for hover/shadow motion.
+- WCAG 2.2 AA: visible focus, ≥44×44px targets, channel meaning via icon + label (not colour alone).
+- Scope v1: public chrome, homepage, Account menu, tokens. Defer article redesign, Editor.js, admin tables, custom SVG mascots.
+- Do not commit unrelated dirty mailing/engagement files already present in the working tree.
+
+## File structure
+
+| File | Responsibility |
+|------|----------------|
+| `resources/css/app.css` | Page tint, radius, chunky-shadow utilities |
+| `docs/design/tokens.md` | Document new tokens |
+| `resources/js/types/page.ts` | Shared Inertia `auth` prop types |
+| `app/Http/Middleware/HandleInertiaRequests.php` | Share `auth.can.accessStaff` / `accessAdmin` |
+| `tests/Feature/SharedAuthPropsTest.php` | Assert shared capability flags by role |
+| `resources/js/Components/Layout/AccountMenu.tsx` | Role-gated disclosure menu |
+| `resources/js/Components/Layout/SiteFooter.tsx` | Legal/mailing footer links |
+| `resources/js/Components/Layout/PublicLayout.tsx` | Skip link, header, brand, children, footer |
+| `resources/js/Components/Home/ChannelTrailTile.tsx` | Channel trail tile |
+| `resources/js/Components/Home/DeskPanel.tsx` | “On the desk” panel + story rows |
+| `resources/js/channelMeta.ts` | Slug → icon, hint, accent class map |
+| `resources/js/Pages/home.tsx` | Split-desk homepage |
+| `resources/js/Pages/{Search,Channels,Articles,Archives,Mailing/Signup,Legal}/*` | Wrap with `PublicLayout` |
+| `docs/design/component-inventory.md` | Register new components |
+| `tests/Feature/HomePageTest.php` | Homepage still renders; channels/featured shape |
+
+---
+
+### Task 1: Friendly Guide design tokens
+
+**Files:**
+- Modify: `resources/css/app.css`
+- Modify: `docs/design/tokens.md`
+- Test: visual/CSS — verified by `npm run build` (no JS unit test suite)
+
+**Interfaces:**
+- Consumes: existing `@theme` colours in `app.css`
+- Produces: `--color-page-tint`, `--radius-tile`, utility classes `.shadow-chunky-apes`, `.shadow-chunky-shelter`, `.shadow-chunky-clinic`, `.shadow-chunky-ink`, and `bg-page-tint` via theme colour
+
+- [ ] **Step 1: Extend `@theme` and utilities in `app.css`**
+
+Add inside `@theme { ... }`:
+
+```css
+--color-page-tint: #F7FBF9;
+--radius-tile: 1rem;
+```
+
+Append after the `@theme` block:
+
+```css
+.shadow-chunky-apes {
+    box-shadow: 4px 4px 0 var(--color-apes-primary);
+}
+.shadow-chunky-shelter {
+    box-shadow: 4px 4px 0 var(--color-shelter-accent);
+}
+.shadow-chunky-clinic {
+    box-shadow: 4px 4px 0 var(--color-clinic-accent);
+}
+.shadow-chunky-ink {
+    box-shadow: 4px 4px 0 var(--color-neutral-900);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .shadow-chunky-apes,
+    .shadow-chunky-shelter,
+    .shadow-chunky-clinic,
+    .shadow-chunky-ink {
+        transition: none;
+    }
+}
+```
+
+- [ ] **Step 2: Document tokens in `docs/design/tokens.md`**
+
+Under Colour, add `--color-page-tint` `#F7FBF9` (page backgrounds).  
+Under a new **Friendly Guide surfaces** subsection, document `--radius-tile` `1rem` and the four `.shadow-chunky-*` utilities. Note: chunky shadows are for trail tiles / desk panels only.
+
+- [ ] **Step 3: Verify CSS builds**
+
+Run: `npm run build`  
+Expected: Vite build succeeds (exit 0).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/css/app.css docs/design/tokens.md
+git commit -m "feat: add Friendly Guide surface tokens for #27"
+```
+
+---
+
+### Task 2: Share auth capability flags
+
+**Files:**
+- Modify: `app/Http/Middleware/HandleInertiaRequests.php`
+- Create: `resources/js/types/page.ts`
+- Create: `tests/Feature/SharedAuthPropsTest.php`
+
+**Interfaces:**
+- Consumes: `App\Enums\Role`, `$request->user()?->role`
+- Produces: shared Inertia props
+
+```ts
+// resources/js/types/page.ts
+export type AuthUser = {
+    id: number;
+    name: string;
+    email: string;
+    role: 'public' | 'staff' | 'admin' | 'super_admin';
+};
+
+export type SharedAuth = {
+    user: AuthUser | null;
+    can: {
+        accessStaff: boolean;
+        accessAdmin: boolean;
+    };
+};
+
+export type SharedPageProps = {
+    appName: string;
+    auth: SharedAuth;
+    devTools?: boolean;
+    flash?: { status?: string | null };
+};
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Feature/SharedAuthPropsTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class SharedAuthPropsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_has_no_staff_or_admin_access_flags(): void
+    {
+        $this->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('auth.user', null)
+                ->where('auth.can.accessStaff', false)
+                ->where('auth.can.accessAdmin', false));
+    }
+
+    public function test_public_user_has_no_staff_or_admin_access_flags(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('auth.user.role', 'public')
+                ->where('auth.can.accessStaff', false)
+                ->where('auth.can.accessAdmin', false));
+    }
+
+    public function test_staff_can_access_staff_but_not_admin(): void
+    {
+        $user = User::factory()->staff()->create();
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('auth.can.accessStaff', true)
+                ->where('auth.can.accessAdmin', false));
+    }
+
+    public function test_admin_can_access_staff_and_admin(): void
+    {
+        $user = User::factory()->admin()->create();
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('auth.can.accessStaff', true)
+                ->where('auth.can.accessAdmin', true));
+    }
+
+    public function test_super_admin_can_access_staff_and_admin(): void
+    {
+        $user = User::factory()->superAdmin()->create();
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('auth.can.accessStaff', true)
+                ->where('auth.can.accessAdmin', true));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `php artisan test --filter=SharedAuthPropsTest`  
+Expected: FAIL (missing `auth.can.*` props).
+
+- [ ] **Step 3: Implement shared props + types**
+
+Update `HandleInertiaRequests::share()` auth block to:
+
+```php
+use App\Enums\Role;
+
+// inside share():
+'auth' => [
+    'user' => $request->user()?->only(['id', 'name', 'email', 'role']),
+    'can' => [
+        'accessStaff' => $request->user()?->role->atLeast(Role::Staff) ?? false,
+        'accessAdmin' => $request->user()?->role->atLeast(Role::Admin) ?? false,
+    ],
+],
+```
+
+Create `resources/js/types/page.ts` with the types listed in **Interfaces** above.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `php artisan test --filter=SharedAuthPropsTest`  
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Http/Middleware/HandleInertiaRequests.php resources/js/types/page.ts tests/Feature/SharedAuthPropsTest.php
+git commit -m "feat: share staff/admin capability flags with Inertia for #27"
+```
+
+---
+
+### Task 3: PublicLayout, AccountMenu, SiteFooter
+
+**Files:**
+- Create: `resources/js/Components/Layout/AccountMenu.tsx`
+- Create: `resources/js/Components/Layout/SiteFooter.tsx`
+- Create: `resources/js/Components/Layout/PublicLayout.tsx`
+- Test: `npm run typecheck` (React has no unit runner; capability gating covered by Task 2 props)
+
+**Interfaces:**
+- Consumes: `SharedPageProps` via `usePage<SharedPageProps>()`
+- Produces:
+
+```tsx
+// PublicLayout props
+type PublicLayoutProps = {
+    children: React.ReactNode;
+    title?: string; // optional; pages may still set <Head> themselves
+};
+```
+
+Account menu URLs (fixed):
+- Profile → `/account`
+- Admin panel → `/admin/moderation` (only if `auth.can.accessAdmin`)
+- Staff desk → `/staff/posts` (only if `auth.can.accessStaff`)
+- Sign out → `POST /logout` via Inertia `<Link method="post" href="/logout" as="button">`
+- Guests: links to `/login` and `/register`
+
+- [ ] **Step 1: Create `AccountMenu.tsx`**
+
+```tsx
+import { Link, usePage } from '@inertiajs/react';
+import { useEffect, useId, useRef, useState } from 'react';
+import type { SharedPageProps } from '../../types/page';
+
+export default function AccountMenu() {
+    const { auth } = usePage<SharedPageProps>().props;
+    const [open, setOpen] = useState(false);
+    const menuId = useId();
+    const rootRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!open) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setOpen(false);
+        };
+        const onClick = (e: MouseEvent) => {
+            if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener('keydown', onKey);
+        document.addEventListener('mousedown', onClick);
+        return () => {
+            document.removeEventListener('keydown', onKey);
+            document.removeEventListener('mousedown', onClick);
+        };
+    }, [open]);
+
+    if (!auth.user) {
+        return (
+            <div className="flex items-center gap-3 text-sm">
+                <Link href="/login" className="text-neutral-600 hover:text-neutral-900">
+                    Login
+                </Link>
+                <Link
+                    href="/register"
+                    className="rounded-lg border border-apes-primary bg-white px-3 py-2 font-semibold text-apes-primary"
+                >
+                    Register
+                </Link>
+            </div>
+        );
+    }
+
+    return (
+        <div className="relative" ref={rootRef}>
+            <button
+                type="button"
+                className="min-h-11 rounded-lg border border-apes-primary bg-[#e8f2ec] px-3 py-2 text-sm font-bold text-[#1b4332]"
+                aria-expanded={open}
+                aria-controls={menuId}
+                onClick={() => setOpen((v) => !v)}
+            >
+                You ▾
+            </button>
+            {open && (
+                <div
+                    id={menuId}
+                    role="menu"
+                    className="absolute right-0 z-20 mt-2 min-w-[10rem] rounded-xl border-2 border-neutral-900 bg-white py-1 shadow-chunky-ink"
+                >
+                    <Link
+                        href="/account"
+                        role="menuitem"
+                        className="block px-3 py-2 text-sm text-neutral-600 hover:bg-neutral-100"
+                        onClick={() => setOpen(false)}
+                    >
+                        Profile
+                    </Link>
+                    {auth.can.accessAdmin && (
+                        <Link
+                            href="/admin/moderation"
+                            role="menuitem"
+                            className="block bg-[#e8f2ec] px-3 py-2 text-sm font-bold text-[#1b4332] hover:bg-[#d8e8df]"
+                            onClick={() => setOpen(false)}
+                        >
+                            Admin panel
+                        </Link>
+                    )}
+                    {auth.can.accessStaff && (
+                        <Link
+                            href="/staff/posts"
+                            role="menuitem"
+                            className="block px-3 py-2 text-sm text-neutral-600 hover:bg-neutral-100"
+                            onClick={() => setOpen(false)}
+                        >
+                            Staff desk
+                        </Link>
+                    )}
+                    <Link
+                        href="/logout"
+                        method="post"
+                        as="button"
+                        role="menuitem"
+                        className="block w-full px-3 py-2 text-left text-sm text-neutral-600 hover:bg-neutral-100"
+                        onClick={() => setOpen(false)}
+                    >
+                        Sign out
+                    </Link>
+                </div>
+            )}
+        </div>
+    );
+}
+```
+
+- [ ] **Step 2: Create `SiteFooter.tsx`**
+
+```tsx
+import { Link } from '@inertiajs/react';
+
+export default function SiteFooter() {
+    return (
+        <footer className="border-t border-neutral-200 py-8">
+            <div className="mx-auto flex max-w-5xl flex-wrap gap-4 px-6 text-sm text-neutral-600">
+                <Link href="/legal/privacy">Privacy</Link>
+                <Link href="/legal/cookies">Cookies</Link>
+                <Link href="/legal/rights">Your rights</Link>
+                <Link href="/mailing/signup">Mailing lists</Link>
+            </div>
+        </footer>
+    );
+}
+```
+
+- [ ] **Step 3: Create `PublicLayout.tsx`**
+
+```tsx
+import { Link } from '@inertiajs/react';
+import AccountMenu from './AccountMenu';
+import SiteFooter from './SiteFooter';
+
+export default function PublicLayout({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="min-h-screen bg-page-tint text-neutral-900">
+            <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-white focus:px-3 focus:py-2 focus:outline focus:outline-2 focus:outline-focus">
+                Skip to main content
+            </a>
+            <header className="border-b border-[#d8e8df] bg-white">
+                <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-4">
+                    <Link href="/" className="flex items-center gap-2">
+                        <span className="flex h-7 w-7 items-center justify-center rounded-[10px] bg-apes-primary text-sm font-extrabold text-white">
+                            A
+                        </span>
+                        <span className="text-base font-semibold text-apes-primary">APES Newsroom</span>
+                    </Link>
+                    <div className="flex items-center gap-4">
+                        <Link href="/search" className="text-sm text-neutral-600 hover:text-neutral-900">
+                            Search
+                        </Link>
+                        <AccountMenu />
+                    </div>
+                </div>
+            </header>
+            {children}
+            <SiteFooter />
+        </div>
+    );
+}
+```
+
+Note: Tailwind maps `--color-page-tint` to `bg-page-tint` via `@theme`. If the class is purged/unknown, use `style={{ backgroundColor: 'var(--color-page-tint)' }}` or `bg-[var(--color-page-tint)]`.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`  
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js/Components/Layout
+git commit -m "feat: add PublicLayout and AccountMenu with role-gated links for #27"
+```
+
+---
+
+### Task 4: Homepage split-desk layout
+
+**Files:**
+- Create: `resources/js/channelMeta.ts`
+- Create: `resources/js/Components/Home/ChannelTrailTile.tsx`
+- Create: `resources/js/Components/Home/DeskPanel.tsx`
+- Modify: `resources/js/Pages/home.tsx`
+- Modify: `tests/Feature/HomePageTest.php`
+
+**Interfaces:**
+- Consumes: existing home props `{ featured?, recent, channels: { slug, label }[] }`
+- Produces: channel meta helper
+
+```ts
+// resources/js/channelMeta.ts
+export type ChannelAccent = 'apes' | 'shelter' | 'clinic';
+
+export type ChannelMeta = {
+    icon: string;
+    hint: string;
+    accent: ChannelAccent;
+    shadowClass: string;
+    borderClass: string;
+    badgeClass: string;
+};
+
+export const channelMetaBySlug: Record<string, ChannelMeta> = {
+    'apes-cic': {
+        icon: '🌳',
+        hint: 'Mission stories',
+        accent: 'apes',
+        shadowClass: 'shadow-chunky-apes',
+        borderClass: 'border-apes-primary',
+        badgeClass: 'bg-[#e8f2ec] text-apes-primary',
+    },
+    'apes-shelter-rescue': {
+        icon: '🏠',
+        hint: 'Shelter & rescue updates',
+        accent: 'shelter',
+        shadowClass: 'shadow-chunky-shelter',
+        borderClass: 'border-shelter-accent',
+        badgeClass: 'bg-[#f5e6d8] text-shelter-accent',
+    },
+    'apes-pet-care-clinic': {
+        icon: '💉',
+        hint: 'Clinic notes',
+        accent: 'clinic',
+        shadowClass: 'shadow-chunky-clinic',
+        borderClass: 'border-clinic-accent',
+        badgeClass: 'bg-[#e3f0f7] text-clinic-accent',
+    },
+};
+```
+
+- [ ] **Step 1: Extend homepage feature test**
+
+Replace/extend `tests/Feature/HomePageTest.php` to assert channels payload shape (existing controller already sends `slug` + `label`):
+
+```php
+public function test_the_homepage_renders_via_inertia(): void
+{
+    $response = $this->get('/');
+
+    $response->assertOk();
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('home')
+        ->has('channels', 3)
+        ->has('channels.0', fn (Assert $c) => $c
+            ->has('slug')
+            ->has('label')
+            ->etc())
+        ->has('recent')
+        ->has('featured'));
+}
+```
+
+- [ ] **Step 2: Run test — should still pass against current homepage**
+
+Run: `php artisan test --filter=HomePageTest`  
+Expected: PASS (props already exist).
+
+- [ ] **Step 3: Add `channelMeta.ts`, `ChannelTrailTile.tsx`, `DeskPanel.tsx`**
+
+`ChannelTrailTile.tsx`:
+
+```tsx
+import { Link } from '@inertiajs/react';
+import { channelMetaBySlug } from '../../channelMeta';
+
+export default function ChannelTrailTile({ slug, label }: { slug: string; label: string }) {
+    const meta = channelMetaBySlug[slug];
+    if (!meta) return null;
+
+    return (
+        <Link
+            href={`/${slug}`}
+            className={`flex min-h-11 flex-1 flex-col justify-center rounded-2xl border-2 bg-white p-3 ${meta.borderClass} ${meta.shadowClass} focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-focus`}
+        >
+            <span className="text-2xl" aria-hidden="true">
+                {meta.icon}
+            </span>
+            <span className="mt-1 text-sm font-extrabold">{label}</span>
+            <span className="text-xs text-neutral-600">{meta.hint}</span>
+        </Link>
+    );
+}
+```
+
+`DeskPanel.tsx`: accept `featured` and `recent` with the existing `PostCard` shape; render “On the desk” label, featured block with CTA `Link` to `/articles/{slug}`, dashed divider, then recent rows with channel badge (label text + `badgeClass` from `channelMetaBySlug[channel_slug]`).
+
+- [ ] **Step 4: Rewrite `home.tsx` to use PublicLayout + split desk**
+
+Structure:
+
+```tsx
+<PublicLayout>
+  <Head title="Home" />
+  <main id="main-content" className="mx-auto max-w-5xl px-6 py-10">
+    <div className="grid gap-6 md:grid-cols-[2fr_3fr]">
+      <div className="order-2 flex flex-col gap-3 md:order-1">
+        {channels.map((c) => (
+          <ChannelTrailTile key={c.slug} slug={c.slug} label={c.label} />
+        ))}
+      </div>
+      <div className="order-1 md:order-2">
+        <DeskPanel featured={featured} recent={recent} />
+      </div>
+    </div>
+  </main>
+</PublicLayout>
+```
+
+Remove the old inline header/footer from `home.tsx`. Empty state: if no featured and empty recent, DeskPanel shows “No published stories yet.”
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run:
+
+```bash
+php artisan test --filter=HomePageTest
+npm run typecheck
+```
+
+Expected: both PASS / exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resources/js/channelMeta.ts resources/js/Components/Home resources/js/Pages/home.tsx tests/Feature/HomePageTest.php
+git commit -m "feat: build Friendly Guide split-desk homepage for #27"
+```
+
+---
+
+### Task 5: Wrap remaining public pages in PublicLayout
+
+**Files:**
+- Modify: `resources/js/Pages/Search/Index.tsx`
+- Modify: `resources/js/Pages/Channels/Show.tsx`
+- Modify: `resources/js/Pages/Articles/Show.tsx`
+- Modify: `resources/js/Pages/Archives/Author.tsx`
+- Modify: `resources/js/Pages/Archives/Tag.tsx`
+- Modify: `resources/js/Pages/Archives/Date.tsx`
+- Modify: `resources/js/Pages/Mailing/Signup.tsx`
+- Modify: `resources/js/Pages/Legal/Privacy.tsx`
+- Modify: `resources/js/Pages/Legal/Cookies.tsx`
+- Modify: `resources/js/Pages/Legal/Rights.tsx`
+- Test: existing feature tests for discovery/mailing/legal + `npm run typecheck`
+
+**Interfaces:**
+- Consumes: `PublicLayout` from Task 3
+- Produces: consistent chrome on listed public surfaces
+
+- [ ] **Step 1: Wrap each listed page**
+
+For each file:
+1. `import PublicLayout from '../../Components/Layout/PublicLayout'` (adjust relative path).
+2. Wrap return in `<PublicLayout>…</PublicLayout>`.
+3. Ensure the page’s primary `<main>` has `id="main-content"` (move id onto existing main if present).
+4. Remove redundant “← Home” / “← APES Newsroom” links only where the header brand already provides navigation home (optional keep on deep archive pages if useful — prefer remove duplicate chrome).
+5. Do **not** change article body `.prose` styling beyond wrapping layout.
+
+Example for Search:
+
+```tsx
+return (
+  <PublicLayout>
+    <Head title="Search" />
+    <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
+      {/* existing content */}
+    </main>
+  </PublicLayout>
+);
+```
+
+- [ ] **Step 2: Run related tests**
+
+Run:
+
+```bash
+php artisan test --filter='DiscoveryTest|HomePageTest|MailingConsentTest|SharedAuthPropsTest'
+npm run typecheck
+npm run lint
+```
+
+Expected: all PASS / exit 0. If a legal page lacks a dedicated test, typecheck is sufficient for that file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Pages
+git commit -m "feat: apply PublicLayout chrome across public pages for #27"
+```
+
+---
+
+### Task 6: Sync component inventory + final verification
+
+**Files:**
+- Modify: `docs/design/component-inventory.md`
+- Test: full suite subset + build
+
+**Interfaces:**
+- Consumes: components from Tasks 3–4
+- Produces: inventory rows for `PublicLayout`, `AccountMenu`, `SiteFooter`, `ChannelTrailTile`, `DeskPanel`
+
+- [ ] **Step 1: Update component inventory**
+
+In `docs/design/component-inventory.md` Layout section, add/replace:
+
+| Component | Description | States |
+|-----------|-------------|--------|
+| `PublicLayout` | Skip link, brand header, Search, AccountMenu, page tint, footer | guest, signed-in |
+| `AccountMenu` | Login/Register or You disclosure with Profile / Admin / Staff / Sign out | guest, public, staff, admin |
+| `SiteFooter` | Privacy, cookies, rights, mailing | default |
+| `ChannelTrailTile` | Channel trail with icon, hint, accent border, chunky shadow | default, focus |
+| `DeskPanel` | “On the desk” featured + recent stack | empty, with featured |
+
+Note Friendly Guide direction and link to `docs/superpowers/specs/2026-08-06-friendly-guide-ui-design.md`.
+
+- [ ] **Step 2: Final verification**
+
+Run:
+
+```bash
+composer test
+composer lint
+npm run typecheck
+npm run lint
+npm run build
+```
+
+Expected: all succeed. If unrelated dirty mailing/engagement changes cause test failures, stash or leave them unstaged and re-run only:
+
+```bash
+php artisan test --filter='SharedAuthPropsTest|HomePageTest|DiscoveryTest|AuthzMatrixTest|DevLoginTest'
+```
+
+- [ ] **Step 3: Comment on #27 and commit docs**
+
+```bash
+git add docs/design/component-inventory.md
+git commit -m "docs: register Friendly Guide components for #27"
+```
+
+Then comment on issue #27 with what shipped vs remaining AC.
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|------------------|------|
+| Friendly Guide personality / chunky shadows / page tint | 1, 4 |
+| Split-desk homepage | 4 |
+| Account-menu Admin + Staff (role-gated) | 2, 3 |
+| Shared public chrome | 3, 5 |
+| Token docs | 1, 6 |
+| Accessibility (focus, Escape, targets, reduced motion) | 1, 3, 4 |
+| Admin hub `/admin/moderation`, Staff `/staff/posts` | 3 |
+| Emoji channel icons | 4 (`channelMeta.ts`) |
+| Deferred article/editor redesign | Out of plan |
+
+## Placeholder / consistency self-review
+
+- No TBD steps; Admin/Staff URLs fixed.
+- `auth.can.accessStaff` / `accessAdmin` naming consistent across middleware, types, AccountMenu, and tests.
+- `PublicLayout` path imports adjust per page depth (`../` vs `../../`).

--- a/docs/superpowers/specs/2026-08-06-friendly-guide-ui-design.md
+++ b/docs/superpowers/specs/2026-08-06-friendly-guide-ui-design.md
@@ -1,0 +1,145 @@
+# Friendly Guide UI — Design Spec
+
+> **Status:** Approved for implementation planning (stakeholder choice 2026-08-06)  
+> **Issue:** [#27](https://github.com/APESCIC/APES-Newsroom/issues/27)  
+> **Relates to:** #1, closed design baseline #2  
+> **Branch:** `cursor/feature/27-friendly-guide-ui`
+
+## Goal
+
+Refresh the public newsroom chrome and homepage with a fun, graphical **Friendly Guide** personality, and expose **Admin** (and Staff desk) via the authenticated **Account menu** for eligible roles only.
+
+## Decisions (locked)
+
+| Decision | Choice |
+|----------|--------|
+| Visual personality | **Friendly Guide** — trail tiles, chunky offset shadows, approachable channel cues |
+| Homepage layout | **Split desk** — channels left; “On the desk” story stack right |
+| Admin entry | **Account menu** — not a persistent header Admin button |
+| Brand colours | Keep existing APES / Shelter / Clinic accents from `docs/design/tokens.md` |
+
+Rejected alternatives (for the record): Living Habitat gradient hero; Story Billboard poster blocks; trails-first or story-led homepage; always-visible Admin header button; dual Staff+Admin header buttons.
+
+## Personality principles
+
+1. **Playful but mission-led** — graphical tiles and shadows; no carnival clutter (no pill clusters, stat strips, or floating promo badges on heroes).
+2. **Channel as trails** — each channel is a tappable “trail” tile with icon, label, short hint, accent border, and offset shadow matching that channel’s colour.
+3. **Newsroom desk metaphor** — the homepage right column is labelled **On the desk**: featured story first, then recent items with channel badges.
+4. **Calm reading elsewhere** — article long-form stays high-contrast and quiet; Friendly Guide energy lives mainly in chrome, homepage, and channel landings.
+5. **Respect reduced motion** — shadow/hover motion is optional and disabled when `prefers-reduced-motion: reduce`.
+
+## Colour & type (delta on existing tokens)
+
+Retain current tokens in `docs/design/tokens.md`. Add Friendly Guide surface tokens:
+
+| Token | Suggested value | Usage |
+|-------|-----------------|-------|
+| `--color-page-tint` | `#F7FBF9` | Page background (soft green tint, not flat grey) |
+| `--shadow-chunky` | `4px 4px 0 var(--accent)` | Trail tiles and desk panel (accent = channel or neutral-900) |
+| `--radius-tile` | `1rem` (16px) | Trail tiles / desk panel |
+| `--font-display` | Instrument Sans (existing `--font-sans`) at heavier weights | UI titles; avoid decorative novelty fonts |
+
+Do **not** introduce purple gradients, cream+terracotta editorial kitsch, or broadsheet hairline newspaper layouts.
+
+Channel accents (unchanged):
+
+- APES CIC: `#2D6A4F`
+- Shelter & Rescue: `#BC6C25`
+- Pet Care Clinic: `#457B9D`
+
+## Layout — homepage (desktop)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ [A] APES Newsroom              Search · You ▾           │
+├──────────────┬──────────────────────────────────────────┤
+│ 🌳 APES CIC  │  ON THE DESK                             │
+│ Mission…     │  Featured title + excerpt + CTA          │
+├──────────────┤  ─────────────────────────────────────── │
+│ 🏠 Shelter   │  [Clinic] recent…                        │
+├──────────────┤  [Shelter] recent…                       │
+│ 💉 Clinic    │  [CIC] recent…                           │
+└──────────────┴──────────────────────────────────────────┘
+```
+
+- **Grid:** ~2fr / 3fr (channels / desk), gap `--space-4`–`--space-6`, max width consistent with current `max-w-5xl` or slightly wider if needed for the two-pane desk.
+- **Trail tiles:** full-height stack; each links to `/{channel_slug}`; keyboard-focusable; 44×44px minimum hit area (tile itself is large).
+- **Desk panel:** white surface, 2px border `--color-neutral-900` (or primary), chunky shadow; featured story; dashed divider; recent list with coloured channel badges (non-colour cue: badge text + position).
+
+### Mobile / tablet
+
+- Stack: header → desk (featured + recent) → trail tiles as a horizontal scroll or 3-up wrap (prefer wrap for accessibility over hidden horizontal scroll).
+- Account menu remains a disclosure button (not hover-only).
+
+## Shared chrome
+
+### Header
+
+- Brand mark: square rounded “A” tile in `--color-apes-primary` + wordmark **APES Newsroom**.
+- Public links: Search (and optional channel links if space; otherwise channels live on homepage trails).
+- Auth:
+  - Guest: **Login** / **Register**.
+  - Signed-in: **You ▾** (or display name) disclosure menu.
+
+### Account menu contents
+
+| Item | Visible when |
+|------|----------------|
+| Profile / Account | Any authenticated user |
+| **Admin panel** | `admin` or `super_admin` → primary admin entry (e.g. `/admin/moderation` or agreed admin hub) |
+| **Staff desk** | `staff`, `admin`, or `super_admin` → `/staff` or `/staff/posts` |
+| Sign out | Any authenticated user |
+
+Rules:
+
+- Never show Admin or Staff links to `public`-only users.
+- Menu must work with keyboard (Escape closes; arrow/tab within).
+- Prefer one Admin destination that lands on a sensible hub; deep links to campaigns/moderation live inside admin UI.
+
+### Footer
+
+Unchanged legal/mailing links; optional quiet Staff link is **not** required if Account menu covers it.
+
+## Components to add / extend
+
+| Component | Responsibility |
+|-----------|----------------|
+| `AppShell` / shared layout | Header, footer, page tint, skip link |
+| `AccountMenu` | Role-gated Admin + Staff desk items |
+| `ChannelTrailTile` | Accent border, icon, label, chunky shadow, link |
+| `DeskPanel` | “On the desk” container |
+| `StoryDeskItem` | Featured + list row with channel badge |
+
+Reuse existing Inertia page props for featured/recent/channels where possible (`resources/js/Pages/home.tsx`).
+
+## Surfaces in scope (v1 of this refresh)
+
+1. Shared public header/footer (all public pages that currently inline chrome).
+2. Homepage split-desk layout.
+3. Account menu Admin + Staff links (role-gated).
+4. Light token/CSS updates for page tint and chunky shadow utility.
+
+### Explicitly deferred
+
+- Full redesign of article typography, Editor.js workspace, moderation tables, email HTML.
+- Custom illustrated SVG mascots (emoji/icon placeholders OK until brand assets land).
+- Channel landing page redesign beyond accent consistency.
+
+## Accessibility
+
+- WCAG 2.2 AA contrast on tinted backgrounds and channel badges.
+- Visible focus rings (`--color-focus`); never remove outlines on tiles/menu.
+- Account menu: `button` + `aria-expanded` / `aria-controls`; focus trap optional if overlay; otherwise natural tab order.
+- Touch targets ≥ 44×44px.
+- Channel meaning not by colour alone (icon + label + badge text).
+- Honour `prefers-reduced-motion`.
+
+## Success criteria
+
+Matches issue #27 acceptance criteria: Friendly Guide chrome, split-desk homepage, role-gated Account-menu Admin/Staff, tokens updated, this spec followed.
+
+## Open implementation notes (resolve in plan, not redesign)
+
+1. Exact Admin hub URL if multiple `/admin/*` routes exist (pick one default).
+2. Whether channel icons are emoji, Lucide/SVG, or brand assets.
+3. Extract shared layout from duplicated page headers vs homepage-only first pass.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -13,7 +13,31 @@
     --color-neutral-900: #1A1A1A;
     --color-neutral-600: #525252;
     --color-neutral-100: #F5F5F4;
+    --color-page-tint: #F7FBF9;
     --color-focus: #2563EB;
+    --radius-tile: 1rem;
+}
+
+.shadow-chunky-apes {
+    box-shadow: 4px 4px 0 var(--color-apes-primary);
+}
+.shadow-chunky-shelter {
+    box-shadow: 4px 4px 0 var(--color-shelter-accent);
+}
+.shadow-chunky-clinic {
+    box-shadow: 4px 4px 0 var(--color-clinic-accent);
+}
+.shadow-chunky-ink {
+    box-shadow: 4px 4px 0 var(--color-neutral-900);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .shadow-chunky-apes,
+    .shadow-chunky-shelter,
+    .shadow-chunky-clinic,
+    .shadow-chunky-ink {
+        transition: none;
+    }
 }
 
 .prose {

--- a/resources/js/Components/Home/ChannelTrailTile.tsx
+++ b/resources/js/Components/Home/ChannelTrailTile.tsx
@@ -1,0 +1,23 @@
+import { Link } from '@inertiajs/react';
+import { channelMetaBySlug } from '../../channelMeta';
+
+export default function ChannelTrailTile({ slug, label }: { slug: string; label: string }) {
+    const meta = channelMetaBySlug[slug];
+
+    if (!meta) {
+        return null;
+    }
+
+    return (
+        <Link
+            href={`/${slug}`}
+            className={`flex min-h-11 flex-1 flex-col justify-center rounded-2xl border-2 bg-white p-3 ${meta.borderClass} ${meta.shadowClass} focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-focus`}
+        >
+            <span className="text-2xl" aria-hidden="true">
+                {meta.icon}
+            </span>
+            <span className="mt-1 text-sm font-extrabold">{label}</span>
+            <span className="text-xs text-neutral-600">{meta.hint}</span>
+        </Link>
+    );
+}

--- a/resources/js/Components/Home/DeskPanel.tsx
+++ b/resources/js/Components/Home/DeskPanel.tsx
@@ -1,0 +1,73 @@
+import { Link } from '@inertiajs/react';
+import { channelMetaBySlug } from '../../channelMeta';
+
+export type PostCard = {
+    title: string;
+    slug: string;
+    excerpt: string | null;
+    channel: string;
+    channel_slug: string;
+    author: string;
+    published_at: string | null;
+};
+
+export default function DeskPanel({
+    featured,
+    recent,
+}: {
+    featured?: PostCard;
+    recent: PostCard[];
+}) {
+    const empty = !featured && recent.length === 0;
+
+    return (
+        <section className="rounded-2xl border-2 border-neutral-900 bg-white p-4 shadow-chunky-ink sm:p-5">
+            <p className="text-[10px] font-bold tracking-widest text-apes-primary uppercase">On the desk</p>
+
+            {empty ? (
+                <p className="mt-4 text-neutral-600">No published stories yet.</p>
+            ) : (
+                <>
+                    {featured && (
+                        <article className="mt-3">
+                            <p className="text-sm text-apes-primary">{featured.channel}</p>
+                            <h2 className="mt-1 text-xl font-extrabold text-[#1b4332] sm:text-2xl">
+                                <Link href={`/articles/${featured.slug}`} className="hover:underline">
+                                    {featured.title}
+                                </Link>
+                            </h2>
+                            {featured.excerpt && <p className="mt-2 text-sm text-neutral-600">{featured.excerpt}</p>}
+                            <Link
+                                href={`/articles/${featured.slug}`}
+                                className="mt-4 inline-block min-h-11 rounded-lg bg-[#ffd166] px-3 py-2 text-sm font-bold text-[#1b4332]"
+                            >
+                                Read story →
+                            </Link>
+                        </article>
+                    )}
+
+                    {recent.length > 0 && (
+                        <ul className="mt-5 space-y-3 border-t border-dashed border-[#cfe3d7] pt-4">
+                            {recent.map((post) => {
+                                const meta = channelMetaBySlug[post.channel_slug];
+
+                                return (
+                                    <li key={post.slug} className="flex flex-wrap items-center gap-2 text-sm">
+                                        <span
+                                            className={`rounded-md px-1.5 py-0.5 text-[10px] font-bold ${meta?.badgeClass ?? 'bg-neutral-100 text-neutral-600'}`}
+                                        >
+                                            {post.channel}
+                                        </span>
+                                        <Link href={`/articles/${post.slug}`} className="font-semibold hover:underline">
+                                            {post.title}
+                                        </Link>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    )}
+                </>
+            )}
+        </section>
+    );
+}

--- a/resources/js/Components/Layout/AccountMenu.tsx
+++ b/resources/js/Components/Layout/AccountMenu.tsx
@@ -1,0 +1,111 @@
+import { Link, usePage } from '@inertiajs/react';
+import { useEffect, useId, useRef, useState } from 'react';
+import type { SharedPageProps } from '../../types/page';
+
+export default function AccountMenu() {
+    const { auth } = usePage<SharedPageProps>().props;
+    const [open, setOpen] = useState(false);
+    const menuId = useId();
+    const rootRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                setOpen(false);
+            }
+        };
+        const onClick = (e: MouseEvent) => {
+            if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
+
+        document.addEventListener('keydown', onKey);
+        document.addEventListener('mousedown', onClick);
+
+        return () => {
+            document.removeEventListener('keydown', onKey);
+            document.removeEventListener('mousedown', onClick);
+        };
+    }, [open]);
+
+    if (!auth.user) {
+        return (
+            <div className="flex items-center gap-3 text-sm">
+                <Link href="/login" className="text-neutral-600 hover:text-neutral-900">
+                    Login
+                </Link>
+                <Link
+                    href="/register"
+                    className="rounded-lg border border-apes-primary bg-white px-3 py-2 font-semibold text-apes-primary"
+                >
+                    Register
+                </Link>
+            </div>
+        );
+    }
+
+    return (
+        <div className="relative" ref={rootRef}>
+            <button
+                type="button"
+                className="min-h-11 rounded-lg border border-apes-primary bg-[#e8f2ec] px-3 py-2 text-sm font-bold text-[#1b4332]"
+                aria-expanded={open}
+                aria-controls={menuId}
+                onClick={() => setOpen((v) => !v)}
+            >
+                You ▾
+            </button>
+            {open && (
+                <div
+                    id={menuId}
+                    role="menu"
+                    className="absolute right-0 z-20 mt-2 min-w-[10rem] rounded-xl border-2 border-neutral-900 bg-white py-1 shadow-chunky-ink"
+                >
+                    <Link
+                        href="/account"
+                        role="menuitem"
+                        className="block px-3 py-2 text-sm text-neutral-600 hover:bg-neutral-100"
+                        onClick={() => setOpen(false)}
+                    >
+                        Profile
+                    </Link>
+                    {auth.can.accessAdmin && (
+                        <Link
+                            href="/admin/moderation"
+                            role="menuitem"
+                            className="block bg-[#e8f2ec] px-3 py-2 text-sm font-bold text-[#1b4332] hover:bg-[#d8e8df]"
+                            onClick={() => setOpen(false)}
+                        >
+                            Admin panel
+                        </Link>
+                    )}
+                    {auth.can.accessStaff && (
+                        <Link
+                            href="/staff/posts"
+                            role="menuitem"
+                            className="block px-3 py-2 text-sm text-neutral-600 hover:bg-neutral-100"
+                            onClick={() => setOpen(false)}
+                        >
+                            Staff desk
+                        </Link>
+                    )}
+                    <Link
+                        href="/logout"
+                        method="post"
+                        as="button"
+                        role="menuitem"
+                        className="block w-full px-3 py-2 text-left text-sm text-neutral-600 hover:bg-neutral-100"
+                        onClick={() => setOpen(false)}
+                    >
+                        Sign out
+                    </Link>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/Components/Layout/PublicLayout.tsx
+++ b/resources/js/Components/Layout/PublicLayout.tsx
@@ -1,0 +1,35 @@
+import { Link } from '@inertiajs/react';
+import type { ReactNode } from 'react';
+import AccountMenu from './AccountMenu';
+import SiteFooter from './SiteFooter';
+
+export default function PublicLayout({ children }: { children: ReactNode }) {
+    return (
+        <div className="min-h-screen bg-page-tint text-neutral-900">
+            <a
+                href="#main-content"
+                className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded focus:bg-white focus:px-3 focus:py-2 focus:outline focus:outline-2 focus:outline-focus"
+            >
+                Skip to main content
+            </a>
+            <header className="border-b border-[#d8e8df] bg-white">
+                <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-4">
+                    <Link href="/" className="flex items-center gap-2">
+                        <span className="flex h-7 w-7 items-center justify-center rounded-[10px] bg-apes-primary text-sm font-extrabold text-white">
+                            A
+                        </span>
+                        <span className="text-base font-semibold text-apes-primary">APES Newsroom</span>
+                    </Link>
+                    <div className="flex items-center gap-4">
+                        <Link href="/search" className="text-sm text-neutral-600 hover:text-neutral-900">
+                            Search
+                        </Link>
+                        <AccountMenu />
+                    </div>
+                </div>
+            </header>
+            {children}
+            <SiteFooter />
+        </div>
+    );
+}

--- a/resources/js/Components/Layout/SiteFooter.tsx
+++ b/resources/js/Components/Layout/SiteFooter.tsx
@@ -1,0 +1,14 @@
+import { Link } from '@inertiajs/react';
+
+export default function SiteFooter() {
+    return (
+        <footer className="border-t border-neutral-200 py-8">
+            <div className="mx-auto flex max-w-5xl flex-wrap gap-4 px-6 text-sm text-neutral-600">
+                <Link href="/legal/privacy">Privacy</Link>
+                <Link href="/legal/cookies">Cookies</Link>
+                <Link href="/legal/rights">Your rights</Link>
+                <Link href="/mailing/signup">Mailing lists</Link>
+            </div>
+        </footer>
+    );
+}

--- a/resources/js/Pages/Archives/Author.tsx
+++ b/resources/js/Pages/Archives/Author.tsx
@@ -1,4 +1,5 @@
 import { Head, Link } from '@inertiajs/react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 type PostCard = {
     title: string;
@@ -25,13 +26,10 @@ function ArchiveShell({
     posts: Paginated;
 }) {
     return (
-        <>
+        <PublicLayout>
             <Head title={title} />
-            <main className="mx-auto max-w-3xl px-6 py-12">
-                <Link href="/" className="text-sm text-neutral-600 underline">
-                    Home
-                </Link>
-                <h1 className="mt-4 text-3xl font-semibold">{heading}</h1>
+            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
+                <h1 className="text-3xl font-semibold">{heading}</h1>
                 {posts.data.length === 0 ? (
                     <p className="mt-6 text-neutral-600">No published stories in this archive.</p>
                 ) : (
@@ -62,7 +60,7 @@ function ArchiveShell({
                     )}
                 </nav>
             </main>
-        </>
+        </PublicLayout>
     );
 }
 

--- a/resources/js/Pages/Archives/Date.tsx
+++ b/resources/js/Pages/Archives/Date.tsx
@@ -1,4 +1,5 @@
 import { Head, Link } from '@inertiajs/react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 type PostCard = {
     title: string;
@@ -24,13 +25,10 @@ export default function DateArchive({
     const label = month ? `${year}-${String(month).padStart(2, '0')}` : String(year);
 
     return (
-        <>
+        <PublicLayout>
             <Head title={`Archive ${label}`} />
-            <main className="mx-auto max-w-3xl px-6 py-12">
-                <Link href="/" className="text-sm text-neutral-600 underline">
-                    Home
-                </Link>
-                <h1 className="mt-4 text-3xl font-semibold">Archive: {label}</h1>
+            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
+                <h1 className="text-3xl font-semibold">Archive: {label}</h1>
                 {posts.data.length === 0 ? (
                     <p className="mt-6 text-neutral-600">No published stories in this period.</p>
                 ) : (
@@ -46,6 +44,6 @@ export default function DateArchive({
                     </ul>
                 )}
             </main>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/Pages/Archives/Tag.tsx
+++ b/resources/js/Pages/Archives/Tag.tsx
@@ -1,4 +1,5 @@
 import { Head, Link } from '@inertiajs/react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 type PostCard = {
     title: string;
@@ -14,13 +15,10 @@ type Paginated = {
 
 export default function TagArchive({ tag, posts }: { tag: { name: string; slug: string }; posts: Paginated }) {
     return (
-        <>
+        <PublicLayout>
             <Head title={`Tag: ${tag.name}`} />
-            <main className="mx-auto max-w-3xl px-6 py-12">
-                <Link href="/" className="text-sm text-neutral-600 underline">
-                    Home
-                </Link>
-                <h1 className="mt-4 text-3xl font-semibold">Tag: {tag.name}</h1>
+            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
+                <h1 className="text-3xl font-semibold">Tag: {tag.name}</h1>
                 {posts.data.length === 0 ? (
                     <p className="mt-6 text-neutral-600">No published stories with this tag.</p>
                 ) : (
@@ -36,6 +34,6 @@ export default function TagArchive({ tag, posts }: { tag: { name: string; slug: 
                     </ul>
                 )}
             </main>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/Pages/Articles/Show.tsx
+++ b/resources/js/Pages/Articles/Show.tsx
@@ -1,5 +1,6 @@
 import { Head, Link, router, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 type Comment = {
     id: number;
@@ -65,7 +66,7 @@ export default function ArticleShow({
     };
 
     return (
-        <>
+        <PublicLayout>
             <Head title={article.meta_title}>
                 <meta name="description" content={article.meta_description ?? ''} />
                 {preview && <meta name="robots" content="noindex,nofollow" />}
@@ -85,7 +86,7 @@ export default function ArticleShow({
             {preview && (
                 <div className="bg-amber-100 px-4 py-2 text-center text-sm text-amber-900">Preview — not indexed</div>
             )}
-            <main className="mx-auto max-w-3xl px-6 py-12">
+            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
                 <Link href={`/${article.channel_slug}`} className="text-sm text-apes-primary">
                     {article.channel}
                 </Link>
@@ -238,6 +239,6 @@ export default function ArticleShow({
                     </section>
                 )}
             </main>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/Pages/Channels/Show.tsx
+++ b/resources/js/Pages/Channels/Show.tsx
@@ -1,4 +1,5 @@
 import { Head, Link } from '@inertiajs/react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 type Post = {
     title: string;
@@ -16,13 +17,10 @@ export default function ChannelShow({
     posts: { data: Post[] };
 }) {
     return (
-        <>
+        <PublicLayout>
             <Head title={channel.label} />
-            <main className="mx-auto max-w-5xl px-6 py-12">
-                <Link href="/" className="text-sm text-neutral-600 hover:underline">
-                    ← Home
-                </Link>
-                <h1 className="mt-4 text-3xl font-semibold text-neutral-900">{channel.label}</h1>
+            <main id="main-content" className="mx-auto max-w-5xl px-6 py-12">
+                <h1 className="text-3xl font-semibold text-neutral-900">{channel.label}</h1>
                 <ul className="mt-8 grid gap-6">
                     {posts.data.map((post) => (
                         <li key={post.slug} className="border-b border-neutral-200 pb-6">
@@ -35,6 +33,6 @@ export default function ChannelShow({
                     ))}
                 </ul>
             </main>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/Pages/Legal/Cookies.tsx
+++ b/resources/js/Pages/Legal/Cookies.tsx
@@ -1,13 +1,11 @@
-import { Head, Link } from '@inertiajs/react';
+import { Head } from '@inertiajs/react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 export default function Cookies() {
     return (
-        <>
+        <PublicLayout>
             <Head title="Cookie notice" />
-            <main className="mx-auto max-w-3xl px-6 py-12 prose prose-neutral">
-                <Link href="/" className="text-sm text-apes-primary no-underline">
-                    ← APES Newsroom
-                </Link>
+            <main id="main-content" className="prose prose-neutral mx-auto max-w-3xl px-6 py-12">
                 <h1>Cookie notice</h1>
                 <p>
                     We use essential cookies and similar storage required to sign you in, protect forms (CSRF), and keep
@@ -18,6 +16,6 @@ export default function Cookies() {
                     will only load after an appropriate consent mechanism and updated notice.
                 </p>
             </main>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/Pages/Legal/Privacy.tsx
+++ b/resources/js/Pages/Legal/Privacy.tsx
@@ -1,13 +1,11 @@
 import { Head, Link } from '@inertiajs/react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 export default function Privacy() {
     return (
-        <>
+        <PublicLayout>
             <Head title="Privacy notice" />
-            <main className="mx-auto max-w-3xl px-6 py-12 prose prose-neutral">
-                <Link href="/" className="text-sm text-apes-primary no-underline">
-                    ← APES Newsroom
-                </Link>
+            <main id="main-content" className="prose prose-neutral mx-auto max-w-3xl px-6 py-12">
                 <h1>Privacy notice</h1>
                 <p>
                     APES Newsroom is operated by APES CIC. This draft notice explains how we process personal data for
@@ -29,6 +27,6 @@ export default function Privacy() {
                 <h2>Contact</h2>
                 <p>Privacy questions: use the contact channels published on the APES CIC website.</p>
             </main>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/Pages/Legal/Rights.tsx
+++ b/resources/js/Pages/Legal/Rights.tsx
@@ -1,13 +1,11 @@
 import { Head, Link } from '@inertiajs/react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 export default function Rights() {
     return (
-        <>
+        <PublicLayout>
             <Head title="Your data rights" />
-            <main className="mx-auto max-w-3xl px-6 py-12 prose prose-neutral">
-                <Link href="/" className="text-sm text-apes-primary no-underline">
-                    ← APES Newsroom
-                </Link>
+            <main id="main-content" className="prose prose-neutral mx-auto max-w-3xl px-6 py-12">
                 <h1>Your data rights</h1>
                 <ul>
                     <li>
@@ -27,6 +25,6 @@ export default function Rights() {
                     </li>
                 </ul>
             </main>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/Pages/Mailing/Signup.tsx
+++ b/resources/js/Pages/Mailing/Signup.tsx
@@ -1,5 +1,6 @@
 import { Head, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 type ListOption = { value: string; label: string; purpose: string };
 
@@ -22,13 +23,13 @@ export default function Signup({ lists, status }: { lists: ListOption[]; status?
     };
 
     return (
-        <>
+        <PublicLayout>
             <Head title="Mailing lists" />
-            <main className="mx-auto max-w-lg px-6 py-12">
+            <main id="main-content" className="mx-auto max-w-lg px-6 py-12">
                 <h1 className="text-2xl font-semibold">APES Newsroom mailing lists</h1>
                 <p className="mt-2 text-sm text-neutral-600">
-                    Choose which APES lists you want. Nothing is pre-selected. We will email you a confirmation
-                    link for each list before sending any news.
+                    Choose which APES lists you want. Nothing is pre-selected. We will email you a confirmation link for
+                    each list before sending any news.
                 </p>
 
                 {status === 'check-email' && (
@@ -67,11 +68,15 @@ export default function Signup({ lists, status }: { lists: ListOption[]; status?
                         {errors.lists && <p className="text-sm text-red-600">{errors.lists}</p>}
                     </fieldset>
 
-                    <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
+                    <button
+                        type="submit"
+                        disabled={processing}
+                        className="w-fit rounded bg-apes-primary px-4 py-2 text-white"
+                    >
                         Subscribe
                     </button>
                 </form>
             </main>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/Pages/Search/Index.tsx
+++ b/resources/js/Pages/Search/Index.tsx
@@ -1,5 +1,6 @@
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 type Result = { title: string; slug: string; excerpt: string | null; published_at: string | null };
 
@@ -12,9 +13,9 @@ export default function SearchIndex({ query, results }: { query: string; results
     };
 
     return (
-        <>
+        <PublicLayout>
             <Head title="Search" />
-            <main className="mx-auto max-w-3xl px-6 py-12">
+            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
                 <h1 className="text-2xl font-semibold">Search</h1>
                 <form onSubmit={submit} className="mt-4 flex gap-2">
                     <label htmlFor="q" className="sr-only">
@@ -42,6 +43,6 @@ export default function SearchIndex({ query, results }: { query: string; results
                     ))}
                 </ul>
             </main>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/Pages/home.tsx
+++ b/resources/js/Pages/home.tsx
@@ -1,14 +1,7 @@
-import { Head, Link } from '@inertiajs/react';
-
-type PostCard = {
-    title: string;
-    slug: string;
-    excerpt: string | null;
-    channel: string;
-    channel_slug: string;
-    author: string;
-    published_at: string | null;
-};
+import { Head } from '@inertiajs/react';
+import ChannelTrailTile from '../Components/Home/ChannelTrailTile';
+import DeskPanel, { type PostCard } from '../Components/Home/DeskPanel';
+import PublicLayout from '../Components/Layout/PublicLayout';
 
 type Channel = { slug: string; label: string };
 
@@ -22,77 +15,20 @@ export default function Home({
     channels: Channel[];
 }) {
     return (
-        <>
+        <PublicLayout>
             <Head title="Home" />
-            <a href="#main-content" className="sr-only focus:not-sr-only">
-                Skip to main content
-            </a>
-            <header className="border-b border-neutral-200 bg-white">
-                <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-                    <Link href="/" className="text-xl font-semibold text-apes-primary">
-                        APES Newsroom
-                    </Link>
-                    <nav className="flex gap-4 text-sm">
-                        {channels.map((c) => (
-                            <Link key={c.slug} href={`/${c.slug}`} className="text-neutral-600 hover:text-neutral-900">
-                                {c.label}
-                            </Link>
+            <main id="main-content" className="mx-auto max-w-5xl px-6 py-10">
+                <div className="grid gap-6 md:grid-cols-[2fr_3fr]">
+                    <div className="order-2 flex flex-col gap-3 md:order-1">
+                        {channels.map((channel) => (
+                            <ChannelTrailTile key={channel.slug} slug={channel.slug} label={channel.label} />
                         ))}
-                        <Link href="/search" className="text-neutral-600 hover:text-neutral-900">
-                            Search
-                        </Link>
-                    </nav>
+                    </div>
+                    <div className="order-1 md:order-2">
+                        <DeskPanel featured={featured} recent={recent} />
+                    </div>
                 </div>
-            </header>
-
-            <main id="main-content" className="mx-auto max-w-5xl px-6 py-12">
-                <section className="mb-12">
-                    <h1 className="text-4xl font-semibold text-neutral-900">Mission-led stories from APES</h1>
-                    <p className="mt-3 max-w-2xl text-lg text-neutral-600">
-                        News and updates from APES CIC, Shelter &amp; Rescue, and Pet Care Clinic.
-                    </p>
-                </section>
-
-                {featured && (
-                    <section className="mb-12">
-                        <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-neutral-600">Featured</h2>
-                        <article className="rounded-lg border border-neutral-200 bg-white p-6">
-                            <p className="text-sm text-apes-primary">{featured.channel}</p>
-                            <h3 className="mt-2 text-2xl font-semibold">
-                                <Link href={`/articles/${featured.slug}`}>{featured.title}</Link>
-                            </h3>
-                            {featured.excerpt && <p className="mt-2 text-neutral-600">{featured.excerpt}</p>}
-                        </article>
-                    </section>
-                )}
-
-                <section>
-                    <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-neutral-600">Recent stories</h2>
-                    {recent.length === 0 ? (
-                        <p className="text-neutral-600">No published stories yet.</p>
-                    ) : (
-                        <ul className="grid gap-6 sm:grid-cols-2">
-                            {recent.map((post) => (
-                                <li key={post.slug} className="rounded-lg border border-neutral-200 bg-white p-5">
-                                    <p className="text-sm text-neutral-600">{post.channel}</p>
-                                    <h3 className="mt-1 text-lg font-semibold">
-                                        <Link href={`/articles/${post.slug}`}>{post.title}</Link>
-                                    </h3>
-                                    {post.excerpt && <p className="mt-2 text-sm text-neutral-600">{post.excerpt}</p>}
-                                </li>
-                            ))}
-                        </ul>
-                    )}
-                </section>
             </main>
-            <footer className="border-t border-neutral-200 py-8">
-                <div className="mx-auto flex max-w-5xl flex-wrap gap-4 px-6 text-sm text-neutral-600">
-                    <Link href="/legal/privacy">Privacy</Link>
-                    <Link href="/legal/cookies">Cookies</Link>
-                    <Link href="/legal/rights">Your rights</Link>
-                    <Link href="/mailing/signup">Mailing lists</Link>
-                </div>
-            </footer>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/channelMeta.ts
+++ b/resources/js/channelMeta.ts
@@ -1,0 +1,37 @@
+export type ChannelAccent = 'apes' | 'shelter' | 'clinic';
+
+export type ChannelMeta = {
+    icon: string;
+    hint: string;
+    accent: ChannelAccent;
+    shadowClass: string;
+    borderClass: string;
+    badgeClass: string;
+};
+
+export const channelMetaBySlug: Record<string, ChannelMeta> = {
+    'apes-cic': {
+        icon: '🌳',
+        hint: 'Mission stories',
+        accent: 'apes',
+        shadowClass: 'shadow-chunky-apes',
+        borderClass: 'border-apes-primary',
+        badgeClass: 'bg-[#e8f2ec] text-apes-primary',
+    },
+    'apes-shelter-rescue': {
+        icon: '🏠',
+        hint: 'Shelter & rescue updates',
+        accent: 'shelter',
+        shadowClass: 'shadow-chunky-shelter',
+        borderClass: 'border-shelter-accent',
+        badgeClass: 'bg-[#f5e6d8] text-shelter-accent',
+    },
+    'apes-pet-care-clinic': {
+        icon: '💉',
+        hint: 'Clinic notes',
+        accent: 'clinic',
+        shadowClass: 'shadow-chunky-clinic',
+        borderClass: 'border-clinic-accent',
+        badgeClass: 'bg-[#e3f0f7] text-clinic-accent',
+    },
+};

--- a/resources/js/types/page.ts
+++ b/resources/js/types/page.ts
@@ -1,0 +1,21 @@
+export type AuthUser = {
+    id: number;
+    name: string;
+    email: string;
+    role: 'public' | 'staff' | 'admin' | 'super_admin';
+};
+
+export type SharedAuth = {
+    user: AuthUser | null;
+    can: {
+        accessStaff: boolean;
+        accessAdmin: boolean;
+    };
+};
+
+export type SharedPageProps = {
+    appName: string;
+    auth: SharedAuth;
+    devTools?: boolean;
+    flash?: { status?: string | null };
+};

--- a/tests/Feature/HomePageTest.php
+++ b/tests/Feature/HomePageTest.php
@@ -15,6 +15,14 @@ class HomePageTest extends TestCase
         $response = $this->get('/');
 
         $response->assertOk();
-        $response->assertInertia(fn (Assert $page) => $page->component('home'));
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('home')
+            ->has('channels', 3)
+            ->has('channels.0', fn (Assert $c) => $c
+                ->has('slug')
+                ->has('label')
+                ->etc())
+            ->has('recent')
+            ->has('featured'));
     }
 }

--- a/tests/Feature/SharedAuthPropsTest.php
+++ b/tests/Feature/SharedAuthPropsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class SharedAuthPropsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_has_no_staff_or_admin_access_flags(): void
+    {
+        $this->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('auth.user', null)
+                ->where('auth.can.accessStaff', false)
+                ->where('auth.can.accessAdmin', false));
+    }
+
+    public function test_public_user_has_no_staff_or_admin_access_flags(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('auth.user.role', 'public')
+                ->where('auth.can.accessStaff', false)
+                ->where('auth.can.accessAdmin', false));
+    }
+
+    public function test_staff_can_access_staff_but_not_admin(): void
+    {
+        $user = User::factory()->staff()->create();
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('auth.can.accessStaff', true)
+                ->where('auth.can.accessAdmin', false));
+    }
+
+    public function test_admin_can_access_staff_and_admin(): void
+    {
+        $user = User::factory()->admin()->create();
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('auth.can.accessStaff', true)
+                ->where('auth.can.accessAdmin', true));
+    }
+
+    public function test_super_admin_can_access_staff_and_admin(): void
+    {
+        $user = User::factory()->superAdmin()->create();
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('auth.can.accessStaff', true)
+                ->where('auth.can.accessAdmin', true));
+    }
+}


### PR DESCRIPTION
﻿## Summary
- Implements the approved Friendly Guide public chrome: page tint, chunky trail tiles, and a split-desk homepage ("On the desk").
- Adds a shared `PublicLayout` with role-gated Account menu links to Admin panel (`/admin/moderation`) and Staff desk (`/staff/posts`).
- Shares `auth.can.accessStaff` / `accessAdmin` via Inertia and wraps key public pages in the new layout.

## Test plan
- [ ] `php artisan test --filter='SharedAuthPropsTest|HomePageTest|DiscoveryTest|AuthzMatrixTest|DevLoginTest'`
- [ ] `npm run typecheck && npm run lint && npm run build`
- [ ] Guest homepage: trail tiles + desk panel; Login/Register in header
- [ ] Public user: Account menu has Profile + Sign out only (no Admin/Staff)
- [ ] Staff: Account menu shows Staff desk, not Admin
- [ ] Admin/super_admin: Account menu shows Admin panel + Staff desk
- [ ] Spot-check Search, article, channel, and legal pages for shared header/footer

Closes #27
