### PR TITLE
fix: link Cloudron OIDC staff to existing email accounts (#29)

### DIFF
--- a/app/Services/Auth/StaffReconciler.php
+++ b/app/Services/Auth/StaffReconciler.php
@@ -38,12 +38,12 @@ class StaffReconciler
 
         $role = collect($matchedRoles)->sortByDesc(fn (Role $role) => $role->rank())->first();
 
+        // Match by OIDC sub or email (any auth_provider). A public/password
+        // account with the same verified email must be linked, not inserted —
+        // otherwise users.email unique constraint fails with a 500.
         $user = User::query()
             ->where('external_id', $identity->sub)
-            ->orWhere(function ($query) use ($identity): void {
-                $query->where('email', $identity->email)
-                    ->where('auth_provider', 'cloudron_oidc');
-            })
+            ->orWhere('email', $identity->email)
             ->first() ?? new User;
 
         $user->forceFill([

--- a/tests/Feature/Auth/StaffOidcLoginTest.php
+++ b/tests/Feature/Auth/StaffOidcLoginTest.php
@@ -167,4 +167,26 @@ class StaffOidcLoginTest extends TestCase
         $this->assertSame('new-sub', $result->user->fresh()->external_id);
         $this->assertSame(1, User::count());
     }
+
+    public function test_existing_password_user_is_linked_instead_of_duplicate_insert(): void
+    {
+        $existing = User::factory()->create([
+            'email' => 'staffer@example.com',
+            'auth_provider' => 'password',
+            'external_id' => null,
+            'role' => Role::Public,
+        ]);
+
+        $result = $this->reconcilerWithGroups([self::STAFF_GROUP])->reconcile($this->identity());
+
+        $this->assertTrue($result->allowed);
+        $this->assertSame($existing->id, $result->user->id);
+        $this->assertSame(1, User::count());
+
+        $existing->refresh();
+        $this->assertSame('cloudron_oidc', $existing->auth_provider);
+        $this->assertSame('oidc-sub-1', $existing->external_id);
+        $this->assertSame(Role::Staff, $existing->role);
+        $this->assertNull($existing->password);
+    }
 }


### PR DESCRIPTION
﻿## Summary
- Fixes Cloudron OIDC staff login when an existing public/password user already owns the same email.
- `StaffReconciler` now matches by OIDC `sub` or email (any `auth_provider`), then upgrades that row to Cloudron OIDC instead of inserting a duplicate that hits the unique email constraint (500).
- Adds a regression test covering password-user → staff OIDC link.

## Test plan
- [ ] `php artisan test --filter=StaffOidcLoginTest`
- [ ] On beta: staff OIDC login with an email that already has a public account succeeds and links (no 500)
- [ ] Confirm existing Cloudron users still reconcile by `external_id` / sub change

Closes #29
