### PR TITLE
fix(import): restore Ghost importer Pint compliance (#33)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Report a reproducible APES Newsroom defect
+title: "[Bug]: "
+type: Bug
+labels:
+  - bug
+assignees:
+  - bmurphy-apescic
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve APES Newsroom. Do not include credentials,
+        personal data, private security details, or unredacted production logs.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: Give a concise description of the defect.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who is affected and how severe is the effect?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Affected version or environment
+      description: Include the release, commit, browser/device, or beta/production environment as applicable.
+      placeholder: e.g. beta at commit abc123, Firefox 128 on Windows 11
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest reliable sequence that demonstrates the problem.
+      placeholder: |
+        1. Go to ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Supporting logs or screenshots
+      description: Add redacted evidence that helps reproduce or diagnose the issue.
+    validations:
+      required: false
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Data-safety confirmation
+      options:
+        - label: I removed secrets, credentials, personal data, and private security details from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: APES Newsroom discussions
+    url: https://github.com/APESCIC/APES-Newsroom/discussions
+    about: Ask questions or discuss ideas that are not yet actionable issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: Feature request
+description: Propose a user-valued APES Newsroom improvement
+title: "[Feature]: "
+type: Feature
+labels:
+  - enhancement
+assignees:
+  - bmurphy-apescic
+body:
+  - type: textarea
+    id: need
+    attributes:
+      label: Underlying need
+      description: What user or operational problem needs solving, and for whom?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the result without assuming a particular implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed approach
+      description: If you have an approach in mind, outline it here.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other options or workarounds have been considered?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: State what should be included and explicitly excluded.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List observable conditions that would make this complete.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies and relationships
+      description: Link related issues, milestones, external decisions, or blocking work.
+    validations:
+      required: false
+  - type: textarea
+    id: implications
+    attributes:
+      label: Security, privacy, and accessibility implications
+      description: Describe relevant risks, data handling, authorization, and inclusive-design needs.
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # APES Newsroom
 
+[![CI](https://github.com/APESCIC/APES-Newsroom/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/APESCIC/APES-Newsroom/actions/workflows/ci.yml)
+
 Public newsroom and authenticated publishing/campaign/moderation
 workspaces for the [Association for the Protection of Exotic Species
 (APES CIC)](https://apes.org.uk), covering APES CIC, APES Shelter &
@@ -9,6 +11,13 @@ See [Issue #1](https://github.com/APESCIC/APES-Newsroom/issues/1) for the
 full epic and [`docs/epic-1-build-plan.md`](docs/epic-1-build-plan.md) for
 how the ten sub-issues sequence against each other. Agents and contributors:
 track work via GitHub Issues per [`AGENTS.md`](AGENTS.md).
+
+## Repository status
+
+Last verified: **2026-08-07T11:37:42+01:00**. APES Newsroom is in active
+pre-release development. Issue #33 restores the PHP formatting baseline, while
+the Direction A interface remains under review in PR #34. Production deployment
+and the Ghost cutover remain separately authorized work.
 
 ## Stack
 
@@ -57,3 +66,13 @@ Guarded, manually-triggered deploy to beta via GitHub Actions - see
 [`docs/deployment.md`](docs/deployment.md) for the full runbook,
 one-time setup, and rollback procedure. Production deployment and the
 Ghost cutover are separately authorized later work (issue #11).
+
+## Project links and support
+
+- [Documentation](docs/epic-1-build-plan.md), [local development](docs/local-dev.md), and [deployment runbook](docs/deployment.md)
+- [Report a bug](https://github.com/APESCIC/APES-Newsroom/issues/new?template=bug_report.yml) or [request a feature](https://github.com/APESCIC/APES-Newsroom/issues/new?template=feature_request.yml)
+- [All issues](https://github.com/APESCIC/APES-Newsroom/issues), [Discussions](https://github.com/APESCIC/APES-Newsroom/discussions), and [Releases](https://github.com/APESCIC/APES-Newsroom/releases)
+
+The repository is maintained by [APES CIC](https://github.com/APESCIC). A
+private security-reporting route is not yet documented; do not disclose
+potential vulnerabilities in a public issue.

--- a/app/Services/Import/GhostContentImporter.php
+++ b/app/Services/Import/GhostContentImporter.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use RuntimeException;
 
 class GhostContentImporter
@@ -280,7 +281,7 @@ class GhostContentImporter
                     'blocks' => $converted['blocks'],
                     'version' => '2.29.0',
                 ]);
-            } catch (\Illuminate\Validation\ValidationException $e) {
+            } catch (ValidationException $e) {
                 $report['warnings'][] = 'Post '.$slug.' failed block validation: '.$e->getMessage();
                 $report['needs_review'][] = $slug;
                 $converted['needs_review'] = true;


### PR DESCRIPTION
## Summary

- Restore the Laravel Pint baseline by importing `ValidationException` and using the imported class in `GhostContentImporter`.
- Keep the importer change behavior-neutral; no data mapping, migration, mail, media, or redirect logic changes.
- Refresh the required README repository-health status and add the already-reviewed issue forms shared with PR #34.

## Root cause

The importer caught `\Illuminate\Validation\ValidationException` inline. Pint's `fully_qualified_strict_types` rule requires the class to be imported and referenced by its short name. This single style finding blocked the Backend job on PR #34 even though the importer was outside that PR.

## Validation

- `composer lint` — passed
- `composer test` — 144 tests passed, 612 assertions
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run build` — passed (existing chunk-size warning only)
- `git diff --check` — passed
- The three issue-form files are byte-identical to their already-reviewed versions in PR #34.

## Boundaries

No importer behavior, routes, database schema, authorization, deployment, Ghost data, campaign sends, or production state changed.

Fixes #33