### PR TITLE
fix(auth): align local LDAP groups with memberOf overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ track work via GitHub Issues per [`AGENTS.md`](AGENTS.md).
 
 ## Repository status
 
-Last verified: **2026-08-07T17:24:38+01:00**. APES Newsroom is in active
+Last verified: **2026-08-09T01:30:42+01:00**. APES Newsroom is in active
 pre-release development. The PHP formatting baseline was restored through
 [issue #33](https://github.com/APESCIC/APES-Newsroom/issues/33); the Direction A
-homepage, staff desk, and admin workspace are tracked by
-[issue #32](https://github.com/APESCIC/APES-Newsroom/issues/32) and delivered for
-review in [PR #34](https://github.com/APESCIC/APES-Newsroom/pull/34).
+homepage, staff desk, and admin workspace were completed in
+[issue #32](https://github.com/APESCIC/APES-Newsroom/issues/32) and merged in
+[PR #34](https://github.com/APESCIC/APES-Newsroom/pull/34).
 Production deployment and the Ghost cutover remain separately authorized work.
 
 ## Stack
@@ -42,7 +42,8 @@ php artisan serve
 
 No MySQL or Redis needed for local dev - `.env.example` defaults to
 sqlite, database-backed sessions/cache/queue. For production-like local
-testing with Redis and OIDC, see [`docs/local-dev.md`](docs/local-dev.md).
+testing with Redis, OpenLDAP, and OIDC, see
+[`docs/local-dev.md`](docs/local-dev.md).
 In Cloudron, `CloudronEnvironmentServiceProvider` (`app/Providers`) overrides
 these from the platform's `CLOUDRON_*` environment variables automatically; see
 that file and `.env.example` for what's mapped.

--- a/app/Services/Auth/LdapGroupLookup.php
+++ b/app/Services/Auth/LdapGroupLookup.php
@@ -36,6 +36,7 @@ class LdapGroupLookup
             $results = Container::getConnection('default')
                 ->query()
                 ->in($usersBaseDn)
+                ->select(['*', 'memberOf'])
                 ->where('mail', '=', $email)
                 ->get();
         } catch (Throwable $e) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
 
   openldap:
     image: osixia/openldap:1.5.0
+    command:
+      - --copy-service
     ports:
       - "389:389"
     environment:

--- a/docker/openldap/bootstrap.ldif
+++ b/docker/openldap/bootstrap.ldif
@@ -1,5 +1,6 @@
 # Test users and groups for local OpenLDAP (docker compose openldap service).
-# Group CNs must match keys in config/rbac.php.
+# Group CNs must match keys in config/rbac.php. Users must be created before
+# groups because the image's memberOf overlay ignores dangling members.
 
 dn: ou=users,dc=apes,dc=local
 objectClass: organizationalUnit
@@ -8,21 +9,6 @@ ou: users
 dn: ou=groups,dc=apes,dc=local
 objectClass: organizationalUnit
 ou: groups
-
-dn: cn=newsroom-staff,ou=groups,dc=apes,dc=local
-objectClass: groupOfNames
-cn: newsroom-staff
-member: cn=staffer,ou=users,dc=apes,dc=local
-
-dn: cn=newsroom-admins,ou=groups,dc=apes,dc=local
-objectClass: groupOfNames
-cn: newsroom-admins
-member: cn=admin,ou=users,dc=apes,dc=local
-
-dn: cn=newsroom-super-admins,ou=groups,dc=apes,dc=local
-objectClass: groupOfNames
-cn: newsroom-super-admins
-member: cn=superadmin,ou=users,dc=apes,dc=local
 
 dn: cn=staffer,ou=users,dc=apes,dc=local
 objectClass: inetOrgPerson
@@ -47,3 +33,18 @@ sn: Admin
 uid: superadmin
 mail: superadmin@apes.local
 userPassword: superadmin
+
+dn: cn=newsroom-staff,ou=groups,dc=apes,dc=local
+objectClass: groupOfUniqueNames
+cn: newsroom-staff
+uniqueMember: cn=staffer,ou=users,dc=apes,dc=local
+
+dn: cn=newsroom-admins,ou=groups,dc=apes,dc=local
+objectClass: groupOfUniqueNames
+cn: newsroom-admins
+uniqueMember: cn=admin,ou=users,dc=apes,dc=local
+
+dn: cn=newsroom-super-admins,ou=groups,dc=apes,dc=local
+objectClass: groupOfUniqueNames
+cn: newsroom-super-admins
+uniqueMember: cn=superadmin,ou=users,dc=apes,dc=local

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -58,7 +58,13 @@ docker compose down
 ```
 
 OpenLDAP is seeded from `docker/openldap/bootstrap.ldif` with test users
-and groups matching `config/rbac.php`.
+and groups matching `config/rbac.php`. The tracked Compose service uses the
+image's `--copy-service` option so its startup scripts can safely process the
+bind-mounted LDIF on Windows and Docker Desktop.
+
+The fixture creates users before its `groupOfUniqueNames` groups. This order
+and the groups' `uniqueMember` attributes match the image's enabled `memberOf`
+overlay, which ignores membership references to users that do not yet exist.
 
 ### 2. Configure `.env`
 
@@ -154,6 +160,39 @@ composer test
 LdapRecord's directory emulator. `LoginPageTest` verifies the staff
 button appears only when OIDC is configured.
 
+### Live OpenLDAP smoke test
+
+The live integration test is intentionally outside the default PHPUnit suites,
+so everyday development and CI do not require Docker. To rebuild only the
+disposable OpenLDAP fixture from the tracked Compose configuration:
+
+```powershell
+docker compose -f docker-compose.yml config
+docker compose -f docker-compose.yml stop openldap
+docker compose -f docker-compose.yml rm -f openldap
+docker compose -f docker-compose.yml up -d openldap
+```
+
+After OpenLDAP is ready, run the opt-in application-level test:
+
+```powershell
+$env:RUN_LIVE_LDAP_TESTS = '1'
+php artisan test tests/Integration/LocalOpenLdapTest.php
+Remove-Item Env:\RUN_LIVE_LDAP_TESTS
+```
+
+The test queries `LdapGroupLookup` for all three fixture users and requires the
+staff, admin, and super-admin group DNs. To inspect only the staff result:
+
+```powershell
+$code = 'echo json_encode(app(\App\Services\Auth\LdapGroupLookup::class)->groupsForEmail("staffer@apes.local"));'
+php artisan tinker --execute=$code
+```
+
+The expected result contains
+`cn=newsroom-staff,ou=groups,dc=apes,dc=local`. Never use production LDAP
+credentials for this fixture test.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
@@ -161,5 +200,6 @@ button appears only when OIDC is configured.
 | `cache: false` on `/health` | Redis not running or wrong host | `docker compose up -d redis`; check `REDIS_HOST` |
 | OIDC redirect mismatch | Wrong redirect URI on client | Register exact callback URL in Cloudron dashboard |
 | Staff login denied (no group) | `memberof` values don't match `config/rbac.php` | Run ldapsearch (see `docs/deployment.md`) and update keys |
+| OpenLDAP exits while loading the fixture on Windows | Container is not using the tracked copy-service behavior | Recreate only OpenLDAP with the commands in the live smoke-test section |
 | LDAP connection timeout | Cloudron LDAP not reachable locally | Use Docker OpenLDAP (option B) |
 | Queue jobs not processing | Worker not running | Start `php artisan queue:work` in a second terminal |

--- a/tests/Integration/LocalOpenLdapTest.php
+++ b/tests/Integration/LocalOpenLdapTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Services\Auth\LdapGroupLookup;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class LocalOpenLdapTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (getenv('RUN_LIVE_LDAP_TESTS') !== '1') {
+            $this->markTestSkipped('Set RUN_LIVE_LDAP_TESTS=1 to query the disposable local OpenLDAP fixture.');
+        }
+    }
+
+    #[DataProvider('localRoleMappings')]
+    public function test_seeded_user_resolves_to_expected_newsroom_group(
+        string $email,
+        string $expectedGroupDn,
+    ): void {
+        $groups = app(LdapGroupLookup::class)->groupsForEmail($email);
+
+        $this->assertContains($expectedGroupDn, $groups);
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function localRoleMappings(): array
+    {
+        return [
+            'staff' => [
+                'staffer@apes.local',
+                'cn=newsroom-staff,ou=groups,dc=apes,dc=local',
+            ],
+            'admin' => [
+                'admin@apes.local',
+                'cn=newsroom-admins,ou=groups,dc=apes,dc=local',
+            ],
+            'super admin' => [
+                'superadmin@apes.local',
+                'cn=newsroom-super-admins,ou=groups,dc=apes,dc=local',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Linked issue

Fixes #38.

## Purpose and scope

Repair the repository's production-like local OpenLDAP fixture so it starts reliably on Windows/Docker Desktop and exposes the `memberOf` data consumed by the application. The change is limited to the disposable local Docker fixture, the LDAP lookup attribute selection, an opt-in live integration test, and local-development documentation.

## Design decisions

- Start `osixia/openldap:1.5.0` with its tracked `--copy-service` behavior so image initialization does not rewrite a bind-mounted LDIF in place on Windows.
- Create fixture users before groups because the enabled overlay ignores dangling membership references.
- Use `groupOfUniqueNames` and `uniqueMember`, matching the image's configured `memberOf` overlay.
- Explicitly select the operational `memberOf` attribute in `LdapGroupLookup`; preserve the existing array-of-DNs return contract.
- Keep the Docker-dependent integration test outside the default PHPUnit suites and require `RUN_LIVE_LDAP_TESTS=1`.

## User-visible effects

Local developers can start the tracked OpenLDAP service without a machine-specific command override, and seeded staff/admin/super-admin users now resolve through the same LDAP role-mapping path used by the application. Production Cloudron LDAP behavior and credentials are unchanged.

## Documentation and changelog effects

- Updated `docs/local-dev.md` with the fixture behavior, scoped reset, and live verification commands.
- Refreshed the README repository-health timestamp and corrected the merged Direction A status.
- No changelog exists, and this local-development fix does not fabricate release history; the README Releases link remains current.

## Local verification

- `composer validate --strict --no-check-publish` — passed
- `composer check-platform-reqs --lock` — passed
- `composer lint` — passed
- `composer test` — passed: 144 tests, 612 assertions
- `RUN_LIVE_LDAP_TESTS=1 php artisan test tests/Integration/LocalOpenLdapTest.php` — passed: 3 tests, 3 assertions
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run test:frontend` — passed: 3 files, 4 tests
- `npm run build` — passed with the existing large-chunk advisory
- `docker compose -f docker-compose.yml config --quiet` — passed
- Tracked-only OpenLDAP recreation and direct `memberOf` inspection — passed
- `php artisan migrate:status --pending` — no pending migrations
- `php artisan deploy:preflight --target=local --dry-run` — passed at commit `603ec55`
- Redis cache/session/queue and `/health` checks — passed
- `git diff --check` — passed; Composer and npm lockfiles unchanged

The repository does not contain `scripts/Sync-CodexAgents.ps1` or `scripts/Sync-CodexGitInstructions.ps1`, so the two required installed-instruction sync checks were unavailable and are not claimed as passed.

## CI status

- PR CI run `31300948910` — passed: Backend (PHP 8.4) and Frontend.
- Verified `main` push CI run `31300990159` for merge commit `97e6d92` — passed: Backend (PHP 8.4) and Frontend.
- Non-blocking annotations: GitHub reports that current `actions/*@v4` dependencies target deprecated Node.js 20 and are being forced onto Node.js 24.

## Risks and rollback

Risk is limited to the optional local OpenLDAP fixture and LDAP attribute retrieval. If the older image behaves differently on another Docker platform, revert commit `603ec55` to restore the previous fixture. The opt-in integration test provides a direct regression check before relying on local role mapping.

## Follow-ups

- #39 separately tracks the deploy-preflight pending-migration detail wording; it does not block this fix.

## Deferred work

Cloudron OIDC configuration, production LDAP credentials, deployment, campaign sends, and Ghost cutover remain out of scope.
