### PR TITLE
fix(deploy): correct pending migration detail (#39)

### DIFF
--- a/app/Console/Commands/DeployPreflightCommand.php
+++ b/app/Console/Commands/DeployPreflightCommand.php
@@ -170,7 +170,9 @@ class DeployPreflightCommand extends Command
         try {
             Artisan::call('migrate:status', ['--pending' => true]);
             $output = Artisan::output();
-            $hasPending = trim($output) !== '' && ! str_contains($output, 'No migrations found');
+            $hasPending = trim($output) !== ''
+                && ! str_contains($output, 'No pending migrations')
+                && ! str_contains($output, 'No migrations found');
 
             $this->record(
                 'database.migrations_pending',

--- a/tests/Feature/DeployPreflightCommandTest.php
+++ b/tests/Feature/DeployPreflightCommandTest.php
@@ -3,15 +3,51 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
 use Tests\TestCase;
 
 class DeployPreflightCommandTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_preflight_command_runs_and_reports_a_result(): void
+    public function test_preflight_reports_an_up_to_date_database_when_no_migrations_are_pending(): void
     {
-        $this->artisan('deploy:preflight')
-            ->assertExitCode(0);
+        $command = Artisan::all()['deploy:preflight'];
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('migrate:status', ['--pending' => true])
+            ->andReturn(0);
+        Artisan::shouldReceive('output')
+            ->once()
+            ->andReturn("\n   INFO  No pending migrations.  \n");
+
+        $tester = new CommandTester($command);
+
+        $this->assertSame(Command::SUCCESS, $tester->execute([]));
+        $this->assertStringContainsString('up to date', $tester->getDisplay());
+    }
+
+    public function test_preflight_reports_when_migrations_are_pending(): void
+    {
+        $command = Artisan::all()['deploy:preflight'];
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('migrate:status', ['--pending' => true])
+            ->andReturn(0);
+        Artisan::shouldReceive('output')
+            ->once()
+            ->andReturn("\n  2026_08_09_000000_create_example_table  Pending  \n");
+
+        $tester = new CommandTester($command);
+
+        $this->assertSame(Command::SUCCESS, $tester->execute([]));
+        $this->assertStringContainsString(
+            'pending migrations exist - deploy will run them',
+            $tester->getDisplay()
+        );
     }
 }


### PR DESCRIPTION
## Linked issue

Fixes #39.

## What changed

- Recognize Laravel's normal `No pending migrations.` output as an up-to-date database.
- Preserve the existing pending-migration advisory and read-only preflight behavior.
- Replace the smoke-only command test with command-level regression coverage for both no-pending and pending output shapes.

## Root cause

`checkPendingMigrations()` treated every non-empty `migrate:status --pending` response as pending unless it contained `No migrations found`. Laravel emits `No pending migrations.` for a fully migrated database, so the informational message was misclassified.

## User/developer impact

A fully migrated database now reports `database.migrations_pending | PASS | up to date`. An unapplied migration still reports `pending migrations exist - deploy will run them`. The command remains read-only, and its safety checks and exit behavior are unchanged.

## Verification

- TDD regression: the no-pending test failed against the old parser and passed after the correction.
- `composer validate --strict --no-check-publish` — passed.
- `composer lint` — passed.
- `composer test` — passed: 145 tests, 619 assertions.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run test:frontend` — passed: 3 files, 4 tests.
- `npm run build` — passed with the existing large-chunk advisory.
- Local SQLite reproduction: `migrate:status --pending` emitted `No pending migrations.`; preflight reported `database.migrations_pending | PASS | up to date`. The overall local preflight exited 1 only because the worktree was intentionally dirty before commit.
- `git diff --check` — passed.

## Boundaries

No migration execution was added to preflight. No deployment, hostname change, live campaign send, production cutover, or Ghost retirement is authorized or performed by this PR.