### PR TITLE
docs: refresh repository and launch records

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,83 +2,132 @@
 
 [![CI](https://github.com/APESCIC/APES-Newsroom/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/APESCIC/APES-Newsroom/actions/workflows/ci.yml)
 
-Public newsroom and authenticated publishing/campaign/moderation
-workspaces for the [Association for the Protection of Exotic Species
-(APES CIC)](https://apes.org.uk), covering APES CIC, APES Shelter &
-Rescue, and APES Pet Care Clinic. Replaces the existing Ghost site.
+APES Newsroom is the mission-led wildlife publishing platform for the
+[Association for the Protection of Exotic Species (APES CIC)](https://apes.org.uk).
+It provides a public newsroom for APES CIC, APES Shelter & Rescue, and APES Pet
+Care Clinic, together with authenticated editorial, campaign, moderation, and
+governance workspaces.
 
-See [Issue #1](https://github.com/APESCIC/APES-Newsroom/issues/1) for the
-full epic and [`docs/epic-1-build-plan.md`](docs/epic-1-build-plan.md) for
-how the ten sub-issues sequence against each other. Agents and contributors:
-track work via GitHub Issues per [`AGENTS.md`](AGENTS.md).
+The production Newsroom is available at
+[www.apesnews.org.uk](https://www.apesnews.org.uk/). The guarded cutover from
+Ghost completed on 2026-08-06 under
+[issue #11](https://github.com/APESCIC/APES-Newsroom/issues/11).
 
 ## Repository status
 
-Last verified: **2026-08-09T01:30:42+01:00**. APES Newsroom is in active
-pre-release development. The PHP formatting baseline was restored through
-[issue #33](https://github.com/APESCIC/APES-Newsroom/issues/33); the Direction A
-homepage, staff desk, and admin workspace were completed in
-[issue #32](https://github.com/APESCIC/APES-Newsroom/issues/32) and merged in
-[PR #34](https://github.com/APESCIC/APES-Newsroom/pull/34).
-Production deployment and the Ghost cutover remain separately authorized work.
+Last verified: **2026-08-10T20:34:02+01:00**.
 
-## Stack
+- `main` is the remote default branch and its CI workflow is current.
+- The public Newsroom is live at `www.apesnews.org.uk`; the apex
+  `apesnews.org.uk` DNS transition was not recorded as complete during cutover.
+- The former Ghost app remains stopped and recoverable at
+  `ghost-legacy.apesnews.org.uk`. Retirement or deletion is not authorized.
+- Live campaign sends remain an explicit operational decision; imports and
+  migration did not send mail.
+- Product and engineering work is tracked in
+  [GitHub Issues](https://github.com/APESCIC/APES-Newsroom/issues). The current
+  frog-led theme exploration remains gated in
+  [issue #36](https://github.com/APESCIC/APES-Newsroom/issues/36).
 
-Laravel 13, Inertia, React, TypeScript, PHP 8.4, MySQL, Redis. Runs on an
-existing Cloudron LAMP app - see [`docs/deployment.md`](docs/deployment.md)
-for how deploys work.
+See [Epic #1](https://github.com/APESCIC/APES-Newsroom/issues/1) and the
+[delivery record](docs/epic-1-build-plan.md) for the original dependency map
+and completion evidence. Agents and contributors must follow
+[`AGENTS.md`](AGENTS.md) and keep issue records current.
+
+## Product capabilities
+
+- Public home, channel, article, author, tag, archive, search, RSS, and sitemap
+  surfaces for the three APES channels.
+- Versioned Editor.js content with staff drafts, review, scheduling, publishing,
+  preview, revisions, redirects, and SEO controls.
+- Password, verification, reset, and magic-link journeys for public accounts;
+  Cloudron OIDC and LDAP-governed roles for staff.
+- Per-channel mailing lists with double opt-in, consent evidence, suppressions,
+  preferences, unsubscribe routes, campaign snapshots, and queued delivery.
+- Moderated public profiles, comments, reports, and reactions.
+- Idempotent Ghost content/media and members CSV import workflows with review
+  flags and fail-closed consent handling.
+- Governance artifacts for privacy, retention, threat modelling, accessibility,
+  deployment, backup, and rollback.
+
+## Architecture
+
+The application uses Laravel 13, PHP 8.4, Inertia, React, TypeScript, Editor.js,
+MySQL, and Redis. Production runs in an existing Cloudron LAMP app. Cloudron
+provides the database, Redis-backed cache/session/queue services, SMTP, OIDC,
+LDAP, backups, and runtime process management.
+
+[`CloudronEnvironmentServiceProvider`](app/Providers/CloudronEnvironmentServiceProvider.php)
+maps the platform's `CLOUDRON_*` environment values without storing credentials
+in this repository. The release layout, queue worker, scheduler, health checks,
+and rollback path are documented in the [deployment runbook](docs/deployment.md).
 
 ## Local setup
 
-```
+Prerequisites are PHP 8.4 with Composer and a current Node.js/npm runtime.
+SQLite and database-backed sessions/cache/queues are sufficient for the default
+local workflow.
+
+```powershell
 composer install
-cp .env.example .env
+Copy-Item .env.example .env
 php artisan key:generate
 php artisan migrate
-npm install
-npm run dev    # or: npm run build
+npm ci
+npm run build
 php artisan serve
 ```
 
-No MySQL or Redis needed for local dev - `.env.example` defaults to
-sqlite, database-backed sessions/cache/queue. For production-like local
-testing with Redis, OpenLDAP, and OIDC, see
-[`docs/local-dev.md`](docs/local-dev.md).
-In Cloudron, `CloudronEnvironmentServiceProvider` (`app/Providers`) overrides
-these from the platform's `CLOUDRON_*` environment variables automatically; see
-that file and `.env.example` for what's mapped.
+Use `npm run dev` instead of the production build while editing frontend code.
+For Redis, OpenLDAP, and OIDC integration, follow
+[`docs/local-dev.md`](docs/local-dev.md). Never commit `.env`, API tokens,
+passwords, personal data, production exports, or application logs.
 
 ## Testing
 
-```
-composer lint        # PHP style (Laravel Pint --test; same as CI)
-composer format      # auto-fix PHP style with Pint
-composer test        # or: php artisan test
+```powershell
+composer test
+composer lint
 npm run typecheck
-npm run lint         # ESLint on resources/js
+npm run lint
 npm run test:frontend
+npm run build
+composer audit --locked
+npm audit
 ```
 
-## Health check
+`composer format` rewrites PHP formatting and should be used only when those
+changes are intended. CI runs the backend/frontend checks against `main`.
 
-`GET /health` reports database and cache connectivity as a plain
-`{"status": "ok", "checks": {...}}` - no configuration or secrets in the
-response. Used by Cloudron and external uptime monitoring.
+## Health and operations
 
-## Deployment
+`GET /health` reports database and cache connectivity as
+`{"status":"ok","checks":{...}}` without returning configuration or secrets.
+It is used by the guarded deployment workflow and external uptime checks.
 
-Guarded, manually-triggered deploy to beta via GitHub Actions - see
-[`docs/deployment.md`](docs/deployment.md) for the full runbook,
-one-time setup, and rollback procedure. Production deployment and the
-Ghost cutover are separately authorized later work (issue #11).
+Deployments are manual, backup-first, versioned, and rollback-capable. Follow
+the [Cloudron deployment runbook](docs/deployment.md) and the
+[beta acceptance record](docs/deployment-beta-acceptance.md). Repository work
+does not by itself authorize a production deployment, DNS change, live campaign
+send, or Ghost retirement.
 
-## Project links and support
+## Documentation and support
 
-- [Documentation](docs/epic-1-build-plan.md), [local development](docs/local-dev.md), and [deployment runbook](docs/deployment.md)
-- [Direction A design record](docs/design/direction-a-ui.md) and [design tokens](docs/design/tokens.md)
-- [Report a bug](https://github.com/APESCIC/APES-Newsroom/issues/new?template=bug_report.yml) or [request a feature](https://github.com/APESCIC/APES-Newsroom/issues/new?template=feature_request.yml)
-- [All issues](https://github.com/APESCIC/APES-Newsroom/issues), [Discussions](https://github.com/APESCIC/APES-Newsroom/discussions), and [Releases](https://github.com/APESCIC/APES-Newsroom/releases)
+- [Delivery plan and dependency record](docs/epic-1-build-plan.md)
+- [Local Redis/OIDC/LDAP development](docs/local-dev.md)
+- [Deployment and rollback](docs/deployment.md)
+- [Beta acceptance evidence](docs/deployment-beta-acceptance.md)
+- [Design records](docs/design/), including
+  [accessibility evidence](docs/design/accessibility-notes.md)
+- [Governance records](docs/governance/), including the
+  [data inventory](docs/governance/data-inventory.md),
+  [retention schedule](docs/governance/retention-schedule.md), and
+  [threat model](docs/governance/threat-model.md)
+- [Security reporting](SECURITY.md)
+- [Report a bug](https://github.com/APESCIC/APES-Newsroom/issues/new?template=bug_report.yml)
+  or [request a feature](https://github.com/APESCIC/APES-Newsroom/issues/new?template=feature_request.yml)
+- [All issues](https://github.com/APESCIC/APES-Newsroom/issues),
+  [Discussions](https://github.com/APESCIC/APES-Newsroom/discussions), and
+  [Releases](https://github.com/APESCIC/APES-Newsroom/releases)
 
-The repository is maintained by [APES CIC](https://github.com/APESCIC). A
-private security-reporting route is not yet documented; do not disclose
-potential vulnerabilities in a public issue.
+The repository is maintained by [APES CIC](https://github.com/APESCIC).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security policy
+
+APES Newsroom is currently a private repository. Security reports must stay
+inside its authorized collaborator group and must not be posted in GitHub
+Discussions, community channels, or an unrelated public repository.
+
+## Report a vulnerability
+
+1. Open a [private repository issue](https://github.com/APESCIC/APES-Newsroom/issues/new?labels=security&assignees=bmurphy-apescic&title=%5BSECURITY%5D%20).
+2. Apply the `security` label and assign `bmurphy-apescic` if the prefilled
+   values are not retained.
+3. Describe the affected surface, observed impact, and safe reproduction steps.
+4. Remove credentials, tokens, session values, personal data, private contact
+   data, production exports, logs, and private infrastructure details before
+   submitting. State that material was removed rather than redacting it inline.
+5. Do not test against production, send live campaigns, change DNS, or access
+   data that you are not authorized to use.
+
+Repository administrators will triage the report privately, agree on a safe
+validation path, and track remediation without publishing exploit details.
+
+## Visibility boundary
+
+This process is private only because the repository and its issues are private.
+GitHub repository security advisories and private vulnerability reporting are
+available for public repositories, not this private-repository workflow. Before
+changing repository visibility, APES CIC must replace this issue-based route
+with a suitable private intake channel and review every existing `security`
+issue for disclosure risk.
+
+See GitHub's documentation on
+[repository security advisories](https://docs.github.com/en/code-security/concepts/vulnerability-reporting-and-management/repository-security-advisories).

--- a/docs/deployment-beta-acceptance.md
+++ b/docs/deployment-beta-acceptance.md
@@ -1,47 +1,50 @@
 # Beta deployment acceptance checklist (issue #3, #11)
 
-Use this checklist during the first watched beta deploy to `beta.apesnews.org.uk`.
-Record evidence (screenshots, command output, timestamps) in issue #3 comments.
+This checklist records the watched beta acceptance completed on 2026-08-06.
+The principal evidence is the
+[#3 deploy and rollback record](https://github.com/APESCIC/APES-Newsroom/issues/3#issuecomment-5208564154),
+the [scheduler follow-up](https://github.com/APESCIC/APES-Newsroom/issues/3#issuecomment-5208596000),
+and the [successful beta surface smoke](https://github.com/APESCIC/APES-Newsroom/issues/11#issuecomment-5208734964).
 
 ## Pre-deploy
 
-- [ ] GitHub `beta` environment secrets configured (`CLOUDRON_FQDN`, `CLOUDRON_TOKEN`, `CLOUDRON_APP_ID`, `CLOUDRON_APP_ORIGIN_HOST`)
-- [ ] One-time server setup complete (PHP 8.4, Apache config, `run.sh`, scheduler cron)
-- [ ] Redis addon enabled and `CLOUDRON_REDIS_*` vars present
-- [ ] OIDC client registered with beta redirect URI
-- [ ] LDAP groups created and `config/rbac.php` keys verified
-- [ ] `php artisan deploy:preflight --target=beta` passes on a clean checkout with `APP_DEBUG=false` and Cloudron database reachable
+- [x] GitHub `beta` environment secrets configured (`CLOUDRON_FQDN`, `CLOUDRON_TOKEN`, `CLOUDRON_APP_ID`, `CLOUDRON_APP_ORIGIN_HOST`)
+- [x] One-time server setup complete (PHP 8.4, Apache config, `run.sh`, scheduler cron)
+- [x] Redis addon enabled and `CLOUDRON_REDIS_*` vars present
+- [x] OIDC client registered with beta redirect URI
+- [x] LDAP groups created and `config/rbac.php` keys verified
+- [x] Guarded deployment preflight passed with Cloudron database/Redis reachable and `APP_DEBUG=false`
 
 ## Deploy execution
 
-- [ ] Trigger "Deploy to Cloudron (beta)" workflow manually from `main`
-- [ ] Cloudron backup created successfully before activation
-- [ ] Migrations run without error
-- [ ] Activate log shows MySQL assert (`www-data artisan targets MySQL`) — not silent sqlite
-- [ ] Health check passes within 60 seconds
-- [ ] Workflow reports success
-- [ ] Homepage `/` returns 200 (not only `/health` / `/login`)
+- [x] Trigger "Deploy to Cloudron (beta)" workflow manually from `main`
+- [x] Cloudron backup created successfully before activation
+- [x] Migrations run without error
+- [x] Activate log shows MySQL assert (`www-data artisan targets MySQL`) — not silent sqlite
+- [x] Health check passes within 60 seconds
+- [x] Workflow reports success
+- [x] Homepage `/` returns 200 (not only `/health` / `/login`)
 
 ## Post-deploy verification
 
 | Check | Command / action | Expected | Evidence |
 |-------|------------------|----------|----------|
-| Health | `curl https://beta.apesnews.org.uk/health` | `database: true`, `cache: true` | |
-| Homepage | Visit `/` | Renders without error | |
-| Login | Visit `/login` | Staff sign-in visible when OIDC configured | |
-| Staff OIDC | Complete staff login | User created with correct role | |
-| Queue worker | Dispatch test job | Job processed via Redis | |
-| Scheduler | Wait for scheduled command | `staff:reconcile-roles` runs daily | |
-| Logs | Check `/app/data/shared/storage/logs/` | No secrets in output | |
+| Health | `curl https://beta.apesnews.org.uk/health` | `database: true`, `cache: true` | #3 final deploy record |
+| Homepage | Visit `/` | Renders without error | #3 smoke: HTTP 200 |
+| Login | Visit `/login` | Staff sign-in visible when OIDC configured | #11 beta smoke |
+| Staff OIDC | Complete staff login | User created with correct role | #4 live proof, referenced by #11 |
+| Queue worker | Dispatch test job | Job processed via Redis | #3 Redis/worker verification |
+| Scheduler | Wait for scheduled command | `staff:reconcile-roles` runs daily | #3 scheduler follow-up |
+| Logs | Check `/app/data/shared/storage/logs/` | No secrets in output | #10 launch-gate approval |
 
 ## Rollback drill
 
-- [ ] Note current release SHA from `/app/data/current`
-- [ ] Run `deploy/cloudron-rollback.sh` via `cloudron exec`
-- [ ] Restart app
-- [ ] Verify previous release serves `/health` successfully
-- [ ] Re-deploy latest release to restore beta to current state
-- [ ] Confirm rollback did not delete release directories
+- [x] Note current release SHA from `/app/data/current`
+- [x] Run `deploy/cloudron-rollback.sh` via `cloudron exec`
+- [x] Restart app
+- [x] Verify previous release serves `/health` successfully
+- [x] Re-deploy latest release to restore beta to current state
+- [x] Confirm rollback did not delete release directories
 
 ## Local preflight evidence (2026-08-06)
 
@@ -56,8 +59,11 @@ Expected local failures (no Cloudron env):
 - `env.debug_disabled` — `APP_DEBUG=true` in local `.env`
 - `database.reachable` — no Cloudron MySQL from local machine
 
-These are expected in local dev. Re-run preflight from CI or a machine with beta `.env` before deploying.
+These were expected in local development and were not treated as beta evidence.
+The watched Cloudron run supplied the guarded-target evidence above.
 
 ## Authorization
 
-Completing this checklist does **not** authorize production cutover (#11) or Ghost retirement.
+Completion of this checklist did not itself authorize production cutover.
+Cutover later received a separate authorization on #11 and completed on
+2026-08-06. Ghost retirement/deletion remains unauthorized.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,19 +1,16 @@
 # Deploying to Cloudron (issue #3)
 
-This documents the guarded deploy pipeline for the existing Cloudron LAMP
-app (`74a2a784-a161-4787-84ff-2b8efc957bc8`), which currently runs Ghost
-and will be repointed at this app per the epic (#1) plan: build and accept
-at `beta.apesnews.org.uk`, then cut over `apesnews.org.uk` separately (#11).
+This documents the guarded deploy pipeline for the existing Cloudron LAMP app
+(`74a2a784-a161-4787-84ff-2b8efc957bc8`). The watched beta deployment and
+rollback drill completed on 2026-08-06 under
+[#3](https://github.com/APESCIC/APES-Newsroom/issues/3#issuecomment-5208564154),
+and the separately authorized production cutover completed under
+[#11](https://github.com/APESCIC/APES-Newsroom/issues/11#issuecomment-5208865545).
+The live app is `www.apesnews.org.uk`.
 
-**Local preflight has been run** (2026-08-06); a watched beta deploy against
-Cloudron has not yet been executed from this environment. See
-[`docs/deployment-beta-acceptance.md`](deployment-beta-acceptance.md) for
-the full acceptance checklist. The workflow, scripts, and setup steps below
-are written and internally consistent against Cloudron's documented
-behaviour (docs.cloudron.io), but there is no Cloudron API token or access
-from this environment to test them end to end. Treat the first real run as
-the acceptance exercise issue #3 and #11 both call for — run it against
-beta, watched, with `docs.cloudron.io` open, before trusting it unattended.
+The workflow and scripts remain the operational runbook for future guarded
+deployments. Treat credentials and production execution as separately
+authorized operations even when following this document.
 
 ## How a release is structured on the server
 
@@ -42,9 +39,10 @@ for inspection until manually cleaned up.
 
 These happen once, outside of CI, before the first deploy can work.
 
-1. **Cloudron dashboard, this app's Location/SSO/etc.** already exist
-   (it's the existing Ghost app being repointed) - no change needed here
-   yet. Repointing DNS/hostname is issue #11's guarded cutover, not this.
+1. **Cloudron dashboard, this app's Location/SSO/etc.** are configured for the
+   Newsroom at `www.apesnews.org.uk`. The former Ghost app remains stopped and
+   recoverable at `ghost-legacy.apesnews.org.uk`. Do not retire it or change the
+   unresolved apex DNS record without separate authorization.
 
 2. **Pin PHP to 8.4** (issue #3 requires PHP 8.4; Cloudron LAMP defaults
    to 8.3):
@@ -148,12 +146,13 @@ before trusting a new environment, and it's what
 failures without Cloudron credentials: uncommitted changes, `APP_DEBUG=true`,
 database unreachable. See [`deployment-beta-acceptance.md`](deployment-beta-acceptance.md).
 
-## What this does not do
+## Operational boundary
 
-Production (`apesnews.org.uk`) deployment is a separate, later workflow
-gated on issue #11's beta acceptance and explicit production
-authorization - it doesn't exist yet, on purpose. This pipeline only ever
-touches beta.
+The same guarded release mechanics now support the live Newsroom, but this
+document does not authorize running them. A future production deployment, DNS
+or hostname change, live campaign send, or Ghost retirement requires its own
+explicit approval and current preflight evidence. The apex `apesnews.org.uk`
+record was not switched during the 2026-08-06 cutover.
 
 ## Redis addon
 

--- a/docs/design/accessibility-notes.md
+++ b/docs/design/accessibility-notes.md
@@ -1,6 +1,10 @@
-# APES Newsroom — Accessibility Notes (draft)
+# APES Newsroom — Accessibility Notes
 
-> **Status:** First-pass draft targeting WCAG 2.2 AA (#2, #10).
+> **Status:** WCAG 2.2 AA launch evidence and named accessibility approval were
+> accepted on 2026-08-06 in
+> [issue #10](https://github.com/APESCIC/APES-Newsroom/issues/10#issuecomment-5208704103).
+> The checklists below remain regression criteria for future changes rather
+> than an indication that the launch gate is open.
 
 ## Global requirements
 
@@ -65,11 +69,11 @@
 
 ## Sign-off
 
-- [ ] Design review complete
-- [ ] Automated checks green
-- [ ] Manual keyboard pass
-- [ ] Screen reader smoke pass
-- [ ] Named accessibility approver recorded
+- [x] Design review complete
+- [x] Automated checks accepted for launch
+- [x] Manual accessibility evidence accepted for launch
+- [ ] A distinct screen-reader smoke run is not separately identified in the durable issue record
+- [x] Named accessibility approver recorded: Bambie Murphy, APES CIC / repository owner, 2026-08-06
 
 ## Test evidence pointers (code-complete v1)
 
@@ -77,4 +81,5 @@
 - Branded error page `Errors/Show` for 404/410/429/500
 - Engagement controls expose `aria-pressed` on reactions
 - Feature tests cover public reading, engagement gates, and form validation
-- Formal WCAG audit + accessibility sign-off remain open on issue #10
+- Named legal/compliance and accessibility sign-off is recorded on issue #10.
+  This repository record does not claim a separate third-party certification.

--- a/docs/epic-1-build-plan.md
+++ b/docs/epic-1-build-plan.md
@@ -2,17 +2,35 @@
 
 Source: [Issue #1](https://github.com/APESCIC/APES-Newsroom/issues/1) and its sub-issues (#2–#11, #18).
 
-**Code-complete v1 status (2026-08-06):** Engineering acceptance for #5–#9 and #18 is on `main`. Live ops: #2 design approved, #3 beta deploy+rollback done, #4 live OIDC/LDAP proved on beta, #10 governance sign-off recorded. Still open / gated: #11 production cutover (requires separate explicit authorization — not granted by closing #2–#10).
+**Delivery status (2026-08-06):** Engineering acceptance for #2–#10 and #18
+landed on `main`; the watched beta deploy, rollback drill, live OIDC/LDAP proof,
+and named governance/accessibility approvals were recorded on their issues.
+Production cutover was separately authorized and completed under
+[#11](https://github.com/APESCIC/APES-Newsroom/issues/11#issuecomment-5208865545).
+The Newsroom is live at `www.apesnews.org.uk`; the former Ghost app remains
+stopped and recoverable, its retirement is not authorized, and the apex DNS
+record was not switched during cutover.
 
-## What we're building
+## Delivered system
 
-One Laravel 13 + Inertia/React app on the existing Cloudron LAMP app (`74a2a784-a161-4787-84ff-2b8efc957bc8`), with two surfaces: a public SEO newsroom for three APES channels (CIC, Shelter & Rescue, Pet Care Clinic), and authenticated workspaces for publishing, campaigns, moderation, and governance. Public accounts use password/magic-link login; staff use Cloudron OIDC + LDAP role mapping. Content is versioned Editor.js JSON with a server-enforced block allowlist. Mailing lists are per-channel, double opt-in, queued through Cloudron SMTP. Ghost content is imported from Admin export files (content JSON + media archive); mailing lists are imported later via an admin-panel importer that uploads a Ghost members CSV; Ghost isn't retired until a separately authorized cutover.
+One Laravel 13 + Inertia/React app runs on the existing Cloudron LAMP app
+(`74a2a784-a161-4787-84ff-2b8efc957bc8`), with two surfaces: a public SEO
+newsroom for three APES channels (CIC, Shelter & Rescue, Pet Care Clinic), and
+authenticated workspaces for publishing, campaigns, moderation, and governance.
+Public accounts use password/magic-link login; staff use Cloudron OIDC + LDAP
+role mapping. Content is versioned Editor.js JSON with a server-enforced block
+allowlist. Mailing lists are per-channel, double opt-in, and queued through
+Cloudron SMTP. Ghost content and members were imported from exported files with
+fail-closed consent handling; no import sent email.
 
 Shared contracts used across multiple issues: `Role` (public/staff/admin/super_admin), `PostStatus` (draft/in_review/scheduled/published/unpublished/deleted), `MailingList` (apes_cic/apes_shelter_rescue/apes_pet_care_clinic), `ModerationStatus` (private/pending/approved/rejected/suspended), `ReactionType` (helpful/support/thank_you).
 
 ## Authorization boundary (applies throughout)
 
-Every sub-issue repeats some version of this, so it's worth stating once: completing any issue, including the epic, does **not** authorize production deployment, Cloudron hostname changes, live campaign sends, or deleting/retiring Ghost. Those each require separate, explicit sign-off from Bambie when the time comes — this plan doesn't change that.
+Completion of an issue does **not** authorize a new production deployment,
+Cloudron hostname or DNS change, live campaign send, or deletion/retirement of
+Ghost. Production cutover received its own recorded authorization on #11; that
+authorization does not extend to later operational actions.
 
 ## Dependency map
 
@@ -99,12 +117,15 @@ Every sub-issue repeats some version of this, so it's worth stating once: comple
 **Phase 6 — Cutover**
 - **#11 Validate, cut over apesnews.org.uk, retire Ghost safely.** Depends on everything above. Beta acceptance across every surface (including separate content import and **admin-panel** mailing CSV dry-runs), throughput benchmarking, backup/restore/rollback drills, then — only after separate production authorization — the guarded cutover with final content import then final admin-panel mailing import from the uploaded Ghost members CSV, and a defined rollback window. Ghost retirement is a further separate authorization after that window.
 
-## Open questions worth resolving before/while work starts
+## Current follow-up boundaries
 
-Who is doing the #2 design work — is that Bambie/a designer producing wireframes and tokens outside this session, or should I produce a first-pass sitemap/component inventory as a working draft? Access to Cloudron env values, the Cloudron OIDC client, LDAP group names, and Ghost Admin exports (content JSON + media archive for #9; members CSV for #18) will be needed before env wiring and import work can be more than scaffolding — no live Ghost API access is required. And #10's legal/compliance sign-off needs a named approver — worth confirming who that is early rather than at the #11 gate.
-
-## Suggested next step
-
-**Beta is ready.** Remaining gated step:
-
-1. Explicit production authorization from Bambie, then guarded cutover on #11 (final content + mailing imports, hostname move, rollback window). Ghost stays recoverable until a further separate retirement approval.
+- [Issue #36](https://github.com/APESCIC/APES-Newsroom/issues/36) is a new
+  stakeholder-gated theme exploration and is not evidence that the original
+  delivery phases remain incomplete.
+- Ghost stays recoverable until a separate retirement/deletion approval.
+- The apex `apesnews.org.uk` DNS record remains a separately governed change if
+  APES CIC chooses to point it at Cloudron/`www`.
+- Live campaign sends require an explicit operational decision and fresh
+  consent/suppression checks.
+- Dated plans in `docs/superpowers/plans/` are historical implementation
+  records; unchecked boxes there are not the current backlog.

--- a/docs/governance/data-inventory.md
+++ b/docs/governance/data-inventory.md
@@ -1,8 +1,11 @@
 # Data inventory (issue #10)
 
-Draft engineering inventory for APES Newsroom. Legal/compliance sign-off is still required before treating this as approved.
+This engineering inventory and its linked retention, processor, privacy,
+consent, rights, and threat-model records were approved for the launch gate by
+Bambie Murphy (APES CIC / repository owner) on 2026-08-06. See the
+[recorded legal/compliance and accessibility sign-off](https://github.com/APESCIC/APES-Newsroom/issues/10#issuecomment-5208704103).
 
-| Data category | Systems / tables | Lawful basis (draft) | Retention (draft) | Access |
+| Data category | Systems / tables | Lawful basis | Retention | Access |
 |---------------|------------------|----------------------|-------------------|--------|
 | Public account identity | `users` (name, email, password hash, verification) | Contract / legitimate interests for newsroom access | Until account deletion request + 30 days backup | User, admins |
 | Staff identity / roles | `users.role`, OIDC `external_id`, `ldap_group_snapshot` | Legitimate interests (staff access control) | While employed + audit retention | Admins / super admins |
@@ -24,5 +27,5 @@ Draft engineering inventory for APES Newsroom. Legal/compliance sign-off is stil
 
 ## Sign-off
 
-- [ ] Legal / compliance approval recorded on issue #10
-- [ ] Accessibility approval recorded on issue #10
+- [x] Legal / compliance approval recorded on issue #10 (2026-08-06)
+- [x] Accessibility approval recorded on issue #10 (2026-08-06)


### PR DESCRIPTION
## Linked issue

Refs #42

## Purpose and scope

Reconcile APES Newsroom's repository-facing documentation with the verified 2026-08-06 production cutover. This updates the production status, launch evidence, support routes, repository health information, and private security-reporting workflow across seven documentation files.

This pull request makes no runtime, public API, schema, migration, or application-interface changes.

## Design decisions

- Treat the README, Releases route, security policy, and reconciled launch records as the canonical repository documentation because the repository has no changelog.
- Cite the durable deployment, scheduler, beta-smoke, governance, accessibility, and cutover evidence recorded on issues #3, #10, and #11.
- Use a collaborator-only issue workflow for security reports while the repository remains private, with an explicit requirement to replace that route before any visibility change.
- Preserve unresolved or separately governed boundaries for apex DNS, live campaign sends, Ghost retirement, and issue #36.

## User-visible effects

Repository visitors and collaborators receive accurate production status, setup and testing guidance, support links, security-reporting instructions, and launch evidence. The running Newsroom is unchanged.

## Documentation and changelog effects

Updates `README.md`, adds `SECURITY.md`, and reconciles deployment, beta-acceptance, accessibility, build-plan, and governance records. No changelog exists; the README retains the verified Releases link and health-review timestamp `2026-08-10T20:34:02+01:00`.

## Local verification

- `composer validate --strict --no-check-publish` — passed
- `composer test` — passed: 145 tests, 619 assertions
- `composer lint` — passed
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run test:frontend` — passed: 3 files, 4 tests
- `npm run build` — passed; existing JavaScript chunk-size advisory over 500 kB and informational plugin timings only
- `composer audit --locked` — passed: no advisories
- `npm audit` — passed: 0 vulnerabilities
- Repository health review — passed: 18 Markdown files, 29 relative links, live metadata, CI, issue forms, Issues/Discussions/Releases routes, production HTTP 200, and cited #3/#10/#11 evidence
- Diff whitespace, credential, private-data, and generated-artifact scans — passed

## CI status

GitHub Actions checks are pending at pull-request creation. Do not merge until both `Backend (PHP 8.4)` and `Frontend` succeed.

## Risks and rollback

The principal risk is inaccurate or stale operational documentation. The changes are documentation-only and can be rolled back safely by reverting the merge commit; no production state or database rollback is required.

## Follow-ups

Publish issues #47, #45, #44, #43, and #46 in the recorded order after this merge is verified on `main`.

## Deferred work

This pull request does not authorize or perform a deployment, production migration, DNS or hostname change, live campaign send, Ghost retirement, repository visibility change, milestone closure, branch deletion, or work on issue #36.