### PR TITLE
fix(account): preserve editorial records during deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ghost completed on 2026-08-06 under
 
 ## Repository status
 
-Last verified: **2026-08-10T20:34:02+01:00**.
+Last verified: **2026-08-10T21:48:37+01:00**.
 
 - `main` is the remote default branch and its CI workflow is current.
 - The public Newsroom is live at `www.apesnews.org.uk`; the apex

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -3,20 +3,28 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\UpdateAccountRequest;
+use App\Services\Account\AccountDeletionPolicy;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class AccountController extends Controller
 {
+    public function __construct(private readonly AccountDeletionPolicy $deletionPolicy) {}
+
     public function show(Request $request): Response
     {
+        $deletionBlockReason = $this->deletionPolicy->blockingReason($request->user());
+
         return Inertia::render('Account/Profile', [
             'user' => $request->user()->only(['name', 'email', 'role', 'auth_provider']),
             'status' => session('status'),
+            'can_delete_account' => $deletionBlockReason === null,
+            'deletion_block_reason' => $deletionBlockReason,
         ]);
     }
 
@@ -66,13 +74,25 @@ class AccountController extends Controller
     public function destroy(Request $request): RedirectResponse
     {
         $user = $request->user();
+        $deletionBlockReason = DB::transaction(function () use ($user) {
+            $lockedUser = $user->newQuery()->lockForUpdate()->findOrFail($user->id);
+            $reason = $this->deletionPolicy->blockingReason($lockedUser);
+
+            if ($reason === null) {
+                $lockedUser->delete();
+            }
+
+            return $reason;
+        });
+
+        if ($deletionBlockReason !== null) {
+            return back()->withErrors(['delete_account' => $deletionBlockReason]);
+        }
 
         Auth::logout();
 
         $request->session()->invalidate();
         $request->session()->regenerateToken();
-
-        $user->delete();
 
         return redirect()->route('home');
     }

--- a/app/Services/Account/AccountDeletionPolicy.php
+++ b/app/Services/Account/AccountDeletionPolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services\Account;
+
+use App\Enums\Role;
+use App\Models\AuditLog;
+use App\Models\Campaign;
+use App\Models\ImportRun;
+use App\Models\ModerationAudit;
+use App\Models\Post;
+use App\Models\PostRevision;
+use App\Models\User;
+
+class AccountDeletionPolicy
+{
+    public function blockingReason(User $user): ?string
+    {
+        if ($user->role !== Role::Public) {
+            return 'Staff and administrator accounts require an administrator-led retention and erasure process.';
+        }
+
+        if (! in_array($user->auth_provider, [null, 'password'], true)) {
+            return 'Directory-managed accounts require an administrator-led retention and erasure process.';
+        }
+
+        if ($this->hasProtectedRecords($user)) {
+            return 'This account owns protected editorial or audit records and requires an administrator-led retention and erasure process.';
+        }
+
+        return null;
+    }
+
+    private function hasProtectedRecords(User $user): bool
+    {
+        return Post::query()->where('author_id', $user->id)->exists()
+            || PostRevision::query()->where('editor_id', $user->id)->exists()
+            || Campaign::query()->where('created_by', $user->id)->exists()
+            || AuditLog::query()->where('actor_id', $user->id)->exists()
+            || ModerationAudit::query()->where('actor_id', $user->id)->exists()
+            || ImportRun::query()->where('actor_id', $user->id)->exists();
+    }
+}

--- a/database/migrations/2026_08_10_000001_protect_editorial_user_references.php
+++ b/database/migrations/2026_08_10_000001_protect_editorial_user_references.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->replaceUserForeignKey('posts', 'author_id', 'restrict');
+        $this->replaceUserForeignKey('post_revisions', 'editor_id', 'restrict');
+        $this->replaceUserForeignKey('campaigns', 'created_by', 'restrict');
+        $this->replaceUserForeignKey('audit_logs', 'actor_id', 'restrict');
+        $this->replaceUserForeignKey('moderation_audits', 'actor_id', 'restrict');
+        $this->replaceUserForeignKey('import_runs', 'actor_id', 'restrict');
+    }
+
+    public function down(): void
+    {
+        $this->replaceUserForeignKey('posts', 'author_id', 'cascade');
+        $this->replaceUserForeignKey('post_revisions', 'editor_id', 'cascade');
+        $this->replaceUserForeignKey('campaigns', 'created_by', 'cascade');
+        $this->replaceUserForeignKey('audit_logs', 'actor_id', 'set null');
+        $this->replaceUserForeignKey('moderation_audits', 'actor_id', 'set null');
+        $this->replaceUserForeignKey('import_runs', 'actor_id', 'set null');
+    }
+
+    private function replaceUserForeignKey(string $tableName, string $column, string $onDelete): void
+    {
+        Schema::table($tableName, function (Blueprint $table) use ($column, $onDelete) {
+            $table->dropForeign([$column]);
+            $table->foreign($column)->references('id')->on('users')->onDelete($onDelete);
+        });
+    }
+};

--- a/resources/js/Pages/Account/Profile.tsx
+++ b/resources/js/Pages/Account/Profile.tsx
@@ -8,7 +8,14 @@ type ProfileUser = {
     auth_provider: string | null;
 };
 
-export default function Profile({ user, status }: { user: ProfileUser; status?: string }) {
+type ProfileProps = {
+    user: ProfileUser;
+    status?: string;
+    can_delete_account: boolean;
+    deletion_block_reason: string | null;
+};
+
+export default function Profile({ user, status, can_delete_account, deletion_block_reason }: ProfileProps) {
     const { data, setData, patch, processing, errors, delete: destroy } = useForm({
         name: user.name,
         email: user.email,
@@ -24,6 +31,7 @@ export default function Profile({ user, status }: { user: ProfileUser; status?: 
             destroy('/account');
         }
     };
+    const deleteError = (errors as Record<string, string>).delete_account;
 
     return (
         <>
@@ -83,9 +91,14 @@ export default function Profile({ user, status }: { user: ProfileUser; status?: 
 
                 <section className="flex flex-col gap-3 border-t border-neutral-200 pt-6">
                     <h2 className="text-lg font-medium text-red-800">Danger zone</h2>
-                    <button type="button" onClick={deleteAccount} className="w-fit text-sm text-red-700 underline">
-                        Delete account
-                    </button>
+                    {can_delete_account ? (
+                        <button type="button" onClick={deleteAccount} className="w-fit text-sm text-red-700 underline">
+                            Delete account
+                        </button>
+                    ) : (
+                        <p className="text-sm text-neutral-700">{deletion_block_reason}</p>
+                    )}
+                    {deleteError && <p className="text-sm text-red-600">{deleteError}</p>}
                 </section>
 
                 <p className="text-sm">

--- a/resources/js/__tests__/account-deletion.test.tsx
+++ b/resources/js/__tests__/account-deletion.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Profile from '../Pages/Account/Profile';
+
+const publicUser = {
+    name: 'Public Reader',
+    email: 'reader@example.test',
+    role: 'public',
+    auth_provider: 'password',
+};
+
+describe('account self-service deletion', () => {
+    it('shows the action only when the server marks the account eligible', () => {
+        const { rerender } = render(
+            <Profile user={publicUser} can_delete_account deletion_block_reason={null} />,
+        );
+
+        expect(screen.getByRole('button', { name: 'Delete account' })).toBeInTheDocument();
+
+        rerender(
+            <Profile
+                user={{ ...publicUser, role: 'staff', auth_provider: 'cloudron_oidc' }}
+                can_delete_account={false}
+                deletion_block_reason="Staff accounts require an administrator-led process."
+            />,
+        );
+
+        expect(screen.queryByRole('button', { name: 'Delete account' })).not.toBeInTheDocument();
+        expect(screen.getByText('Staff accounts require an administrator-led process.')).toBeInTheDocument();
+    });
+});

--- a/resources/js/test/setup.ts
+++ b/resources/js/test/setup.ts
@@ -24,6 +24,14 @@ vi.mock('@inertiajs/react', async () => {
             return React.createElement(as, as === 'a' ? { ...attributes, href } : attributes, children);
         },
         router: { post: (...args: unknown[]) => getInertiaMock().post(...args) },
+        useForm: <T extends Record<string, unknown>>(initial: T) => ({
+            data: initial,
+            setData: vi.fn(),
+            patch: vi.fn(),
+            processing: false,
+            errors: {},
+            delete: vi.fn(),
+        }),
         usePage: () => getInertiaMock().page,
     };
 });

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -2,13 +2,55 @@
 
 namespace Tests\Feature;
 
+use App\Enums\CampaignStatus;
+use App\Enums\ReactionType;
+use App\Enums\Role;
+use App\Models\AuditLog;
+use App\Models\Campaign;
+use App\Models\Comment;
+use App\Models\ImportRun;
+use App\Models\ModerationAudit;
+use App\Models\ModerationReport;
+use App\Models\Post;
+use App\Models\PostRevision;
+use App\Models\Profile;
+use App\Models\Reaction;
 use App\Models\User;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
 
 class AccountTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
+
+    public function test_account_page_exposes_server_derived_deletion_eligibility(): void
+    {
+        $publicUser = User::factory()->create();
+
+        $this->actingAs($publicUser)
+            ->get(route('account.show'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Account/Profile')
+                ->where('can_delete_account', true)
+                ->where('deletion_block_reason', null));
+
+        $staff = User::factory()->staff()->create();
+
+        $this->actingAs($staff)
+            ->get(route('account.show'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('can_delete_account', false)
+                ->where('deletion_block_reason', fn (?string $reason) => str_contains((string) $reason, 'administrator')));
+    }
 
     public function test_user_can_update_profile(): void
     {
@@ -42,5 +84,177 @@ class AccountTest extends TestCase
 
         $this->assertGuest();
         $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    }
+
+    public function test_privileged_and_oidc_accounts_cannot_call_self_service_deletion_directly(): void
+    {
+        $accounts = collect([Role::Staff, Role::Admin, Role::SuperAdmin])
+            ->flatMap(fn (Role $role) => [
+                User::factory()->create([
+                    'role' => $role,
+                    'auth_provider' => 'password',
+                    'external_id' => null,
+                ]),
+                User::factory()->create([
+                    'role' => $role,
+                    'auth_provider' => 'cloudron_oidc',
+                    'password' => null,
+                    'external_id' => fake()->uuid(),
+                ]),
+            ])
+            ->push(User::factory()->create([
+                'role' => Role::Public,
+                'auth_provider' => 'cloudron_oidc',
+                'password' => null,
+                'external_id' => fake()->uuid(),
+            ]));
+
+        foreach ($accounts as $account) {
+            $this->actingAs($account)
+                ->from(route('account.show'))
+                ->delete(route('account.destroy'))
+                ->assertRedirect(route('account.show'))
+                ->assertSessionHasErrors('delete_account');
+
+            $this->assertAuthenticatedAs($account);
+            $this->assertDatabaseHas('users', ['id' => $account->id]);
+        }
+    }
+
+    public function test_demoted_public_author_is_blocked_without_deleting_editorial_records(): void
+    {
+        $user = User::factory()->create([
+            'role' => Role::Public,
+            'auth_provider' => 'password',
+        ]);
+        $post = Post::factory()->create(['author_id' => $user->id]);
+
+        $this->actingAs($user)
+            ->from(route('account.show'))
+            ->delete(route('account.destroy'))
+            ->assertRedirect(route('account.show'))
+            ->assertSessionHasErrors('delete_account');
+
+        $this->assertAuthenticatedAs($user);
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+        $this->assertDatabaseHas('posts', ['id' => $post->id]);
+    }
+
+    public function test_database_restricts_each_editorial_attribution_independently(): void
+    {
+        $records = [
+            'posts' => fn (User $user) => Post::factory()->create(['author_id' => $user->id]),
+            'post_revisions' => function (User $user) {
+                $post = Post::factory()->create();
+
+                return PostRevision::query()->create([
+                    'post_id' => $post->id,
+                    'editor_id' => $user->id,
+                    'content' => ['blocks' => []],
+                    'title' => 'Protected revision',
+                ]);
+            },
+            'campaigns' => function (User $user) {
+                $post = Post::factory()->create();
+
+                return Campaign::query()->create([
+                    'post_id' => $post->id,
+                    'created_by' => $user->id,
+                    'lists' => ['newsroom'],
+                    'snapshot' => ['subject' => 'Protected campaign'],
+                    'status' => CampaignStatus::Draft,
+                ]);
+            },
+        ];
+
+        foreach ($records as $table => $createRecord) {
+            $user = User::factory()->create();
+            $record = $createRecord($user);
+
+            try {
+                $user->delete();
+                $this->fail("The database removed the protected attribution from {$table}.");
+            } catch (QueryException) {
+                $this->assertDatabaseHas('users', ['id' => $user->id]);
+                $this->assertDatabaseHas($table, ['id' => $record->id]);
+            }
+        }
+    }
+
+    public function test_eligible_public_deletion_removes_public_participation_records(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->create();
+        $profile = Profile::query()->create([
+            'user_id' => $user->id,
+            'display_name' => 'Reader profile',
+        ]);
+        $comment = Comment::query()->create([
+            'post_id' => $post->id,
+            'user_id' => $user->id,
+            'body' => 'A public comment',
+            'body_hash' => hash('sha256', 'A public comment'),
+        ]);
+        $reaction = Reaction::query()->create([
+            'post_id' => $post->id,
+            'user_id' => $user->id,
+            'type' => ReactionType::Helpful,
+        ]);
+        $report = ModerationReport::query()->create([
+            'reporter_id' => $user->id,
+            'reportable_type' => Post::class,
+            'reportable_id' => $post->id,
+            'reason' => 'A public report',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('account.destroy'))
+            ->assertRedirect(route('home'));
+
+        $this->assertGuest();
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+        $this->assertDatabaseMissing('profiles', ['id' => $profile->id]);
+        $this->assertDatabaseMissing('comments', ['id' => $comment->id]);
+        $this->assertDatabaseMissing('reactions', ['id' => $reaction->id]);
+        $this->assertDatabaseMissing('moderation_reports', ['id' => $report->id]);
+        $this->assertDatabaseHas('posts', ['id' => $post->id]);
+    }
+
+    public function test_database_preserves_audit_actor_attribution(): void
+    {
+        $records = [
+            'audit_logs' => fn (User $user) => AuditLog::query()->create([
+                'actor_id' => $user->id,
+                'action' => 'account.test',
+            ]),
+            'moderation_audits' => fn (User $user) => ModerationAudit::query()->create([
+                'actor_id' => $user->id,
+                'subject_type' => User::class,
+                'subject_id' => $user->id,
+                'action' => 'account.test',
+            ]),
+            'import_runs' => fn (User $user) => ImportRun::query()->create([
+                'actor_id' => $user->id,
+                'type' => 'account-test',
+                'status' => 'completed',
+                'dry_run' => true,
+            ]),
+        ];
+
+        foreach ($records as $table => $createRecord) {
+            $user = User::factory()->create();
+            $record = $createRecord($user);
+
+            try {
+                $user->delete();
+                $this->fail("The database removed the actor for {$table}.");
+            } catch (QueryException) {
+                $this->assertDatabaseHas('users', ['id' => $user->id]);
+                $this->assertDatabaseHas($table, [
+                    'id' => $record->id,
+                    'actor_id' => $user->id,
+                ]);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Linked issue

Refs #47

The issue must remain open until this change is merged into the verified remote default branch, both post-merge `main` CI jobs pass, final evidence is recorded, and the issue is closed manually.

## Purpose and scope

Prevent self-service account deletion from removing protected editorial and audit attribution. This change permits deletion only for eligible local public accounts while retaining the established erasure cascades for approved public-participation data.

Scope is limited to the account-deletion policy and endpoint, account-page eligibility contract and UI, restrictive user foreign keys, regression coverage, the shared frontend test mock required by that coverage, and the README health timestamp.

## Design decisions

- Derive eligibility server-side through `AccountDeletionPolicy`; the client cannot grant deletion permission.
- Lock and re-read the user inside the deletion transaction before evaluating eligibility and deleting.
- Return an actionable account-page error without logging out or invalidating the session when deletion is refused.
- Use restrictive foreign keys for post authors, revision editors, campaign creators, audit actors, moderation-audit actors, and import actors.
- Preserve cascades for public participation records such as profiles, comments, reactions, and reports.
- Keep OIDC/directory-managed and privileged accounts on the administrator-led retention and erasure path.

## User-visible effects

Eligible local public accounts continue to see and use the Delete account action. Privileged, directory-managed, and protected-record accounts no longer receive that destructive action and instead see the server-provided reason. Direct refused requests retain the authenticated session.

## Documentation and changelog

The README repository-health review timestamp is updated to `2026-08-10T21:48:37+01:00`. This repository has no changelog; the existing Releases route remains the release-history surface. No other documentation change is required for this focused safety fix.

## Local verification

- `composer validate --strict --no-check-publish` — passed.
- `php artisan test tests/Feature/AccountTest.php` — 9 tests, 121 assertions passed.
- `npm run test:frontend -- resources/js/__tests__/account-deletion.test.tsx` — 1 test passed.
- Temporary-file SQLite `migrate:fresh`, target rollback, and reapply — passed; no production database was used.
- `composer test` — 151 tests, 730 assertions passed.
- `composer lint` — passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run test:frontend` — 4 files, 5 tests passed.
- `npm run build` — passed with the known greater-than-500-kB Vite chunk advisory.
- `composer audit --locked` — no advisories.
- `npm audit` — 0 vulnerabilities.
- README health review — 18 Markdown files, 29 relative links, active CI workflow, issue/support/release routes, exact repository metadata, cited issue evidence, and production URL HTTP 200.
- Browser smoke on this commit — eligible local public, refused privileged local, refused privileged OIDC, and refused public OIDC states passed; refused sessions were retained and consoles were clean.
- Base-to-head whitespace, credential, private-data, and generated-artifact scans — passed with no findings.

## CI status

Pending at PR creation. `Backend (PHP 8.4)` and `Frontend` must both pass before merge authorization is requested; repository permission to merge is not treated as evidence.

## Risks and rollback

The main risks are incorrectly refusing an otherwise eligible deletion, losing historical attribution, or restoring foreign keys with the wrong prior action. Tests cover policy states, direct requests, independent database constraints, participation cascades, and migration rollback/reapply.

Rollback is by reverting the eventual merge commit. If the schema migration has later been applied in a separately authorized environment, its down migration must be performed only through that environment’s governed rollback procedure after compatibility review. No production migration is part of this PR phase.

## Follow-ups

- Wait for both PR CI jobs.
- Obtain separate merge authorization.
- Verify the merge and both post-merge `main` CI jobs.
- Record final evidence, perform the separately controlled manual issue-closure step, and mark its Roadmap item `Done`.
- Continue the authorized publication sequence with #45 only after #47 is fully verified and closed.

## Deferred work

Deployment, production migrations, DNS or hostname changes, live campaign sends, Ghost retirement, milestone closure, branch/worktree deletion, and issue #36 remain outside scope.