### PR TITLE
fix(mailing): make publication campaigns idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ghost completed on 2026-08-06 under
 
 ## Repository status
 
-Last verified: **2026-08-10T21:48:37+01:00**.
+Last verified: **2026-08-10T23:54:55+01:00**.
 
 - `main` is the remote default branch and its CI workflow is current.
 - The public Newsroom is live at `www.apesnews.org.uk`; the apex

--- a/app/Console/Commands/PublishScheduledPostsCommand.php
+++ b/app/Console/Commands/PublishScheduledPostsCommand.php
@@ -23,11 +23,11 @@ class PublishScheduledPostsCommand extends Command
 
     public function handle(): int
     {
-        $posts = Post::query()
+        $postIds = Post::query()
             ->where('status', PostStatus::Scheduled)
             ->whereNotNull('scheduled_for')
             ->where('scheduled_for', '<=', now('Europe/London'))
-            ->get();
+            ->pluck('id');
 
         $systemActor = User::query()
             ->where('role', Role::SuperAdmin)
@@ -35,23 +35,43 @@ class PublishScheduledPostsCommand extends Command
             ->first()
             ?? User::query()->where('role', Role::Admin)->orderBy('id')->first();
 
-        foreach ($posts as $post) {
-            DB::transaction(function () use ($post, $systemActor) {
+        $publishedCount = 0;
+
+        foreach ($postIds as $postId) {
+            $title = DB::transaction(function () use ($postId, $systemActor) {
+                $post = Post::query()
+                    ->whereKey($postId)
+                    ->where('status', PostStatus::Scheduled)
+                    ->whereNotNull('scheduled_for')
+                    ->where('scheduled_for', '<=', now('Europe/London'))
+                    ->lockForUpdate()
+                    ->first();
+
+                if (! $post) {
+                    return null;
+                }
+
+                $actor = $systemActor ?? $post->author()->firstOrFail();
+                $publishedAt = $post->scheduled_for;
+
                 $post->update([
                     'status' => PostStatus::Published,
-                    'published_at' => $post->scheduled_for,
+                    'published_at' => $publishedAt,
                     'scheduled_for' => null,
                 ]);
 
-                if ($systemActor) {
-                    $this->campaigns->createFromPublishedPost($post->fresh(), $systemActor);
-                }
+                $this->campaigns->createFromPublishedPost($post->fresh(), $actor);
+
+                return $post->title;
             });
 
-            $this->line("Published: {$post->title}");
+            if ($title !== null) {
+                $publishedCount++;
+                $this->line("Published: {$title}");
+            }
         }
 
-        $this->info("Published {$posts->count()} scheduled post(s).");
+        $this->info("Published {$publishedCount} scheduled post(s).");
 
         return self::SUCCESS;
     }

--- a/app/Http/Controllers/Staff/PostController.php
+++ b/app/Http/Controllers/Staff/PostController.php
@@ -21,6 +21,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -224,22 +225,36 @@ class PostController extends Controller
     {
         $this->authorizeAdmin();
 
-        if ($post->status === PostStatus::Published) {
-            return back();
-        }
+        $didPublish = false;
+        $publishedPost = DB::transaction(function () use ($request, $post, &$didPublish) {
+            $lockedPost = Post::query()->lockForUpdate()->findOrFail($post->id);
 
-        DB::transaction(function () use ($request, $post) {
-            $post->update([
+            if ($lockedPost->status === PostStatus::Published) {
+                return $lockedPost;
+            }
+
+            if ($lockedPost->status === PostStatus::Deleted) {
+                throw ValidationException::withMessages([
+                    'status' => 'Deleted posts cannot be published.',
+                ]);
+            }
+
+            $lockedPost->update([
                 'status' => PostStatus::Published,
                 'published_at' => now(),
                 'scheduled_for' => null,
                 'review_notes' => null,
             ]);
 
-            $this->campaigns->createFromPublishedPost($post->fresh(), $request->user());
+            $this->campaigns->createFromPublishedPost($lockedPost->fresh(), $request->user());
+            $didPublish = true;
+
+            return $lockedPost->fresh();
         });
 
-        $this->audit->record($request->user(), 'post.published', $post->fresh(), [], $request);
+        if ($didPublish) {
+            $this->audit->record($request->user(), 'post.published', $publishedPost, [], $request);
+        }
 
         return back();
     }

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 #[Fillable([
-    'post_id', 'created_by', 'lists', 'snapshot', 'status',
+    'post_id', 'created_by', 'idempotency_key', 'lists', 'snapshot', 'status',
     'is_test', 'test_recipient', 'queued_at', 'completed_at',
 ])]
 class Campaign extends Model

--- a/app/Services/Mailing/CampaignService.php
+++ b/app/Services/Mailing/CampaignService.php
@@ -23,34 +23,53 @@ class CampaignService
      */
     public function createFromPublishedPost(Post $post, User $actor): ?Campaign
     {
-        if (! $post->email_on_publish) {
-            return null;
-        }
+        return DB::transaction(function () use ($post, $actor) {
+            $lockedPost = Post::query()->lockForUpdate()->findOrFail($post->id);
 
-        $lists = $this->normalizeListValues($post->mailing_lists ?? []);
-        if ($lists === []) {
-            return null;
-        }
+            if (! $lockedPost->email_on_publish) {
+                return null;
+            }
 
-        $existing = Campaign::query()
-            ->where('post_id', $post->id)
-            ->where('is_test', false)
-            ->first();
+            if (! $lockedPost->status->isPubliclyVisible()) {
+                throw new \LogicException('A live campaign can only be created for a published post.');
+            }
 
-        if ($existing) {
-            return $existing;
-        }
+            $lists = $this->normalizeListValues($lockedPost->mailing_lists ?? []);
+            if ($lists === []) {
+                return null;
+            }
 
-        return DB::transaction(function () use ($post, $actor, $lists) {
-            $campaign = Campaign::create([
-                'post_id' => $post->id,
+            $idempotencyKey = 'post:'.$lockedPost->id.':live';
+            $legacyCampaign = Campaign::query()
+                ->where('post_id', $lockedPost->id)
+                ->where('is_test', false)
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->first();
+
+            if ($legacyCampaign) {
+                if ($legacyCampaign->idempotency_key === null) {
+                    $legacyCampaign->update(['idempotency_key' => $idempotencyKey]);
+                }
+
+                return $legacyCampaign->load('recipients');
+            }
+
+            $campaign = Campaign::query()->firstOrCreate([
+                'idempotency_key' => $idempotencyKey,
+            ], [
+                'post_id' => $lockedPost->id,
                 'created_by' => $actor->id,
                 'lists' => $lists,
-                'snapshot' => $this->buildSnapshot($post),
+                'snapshot' => $this->buildSnapshot($lockedPost),
                 'status' => CampaignStatus::Queued,
                 'is_test' => false,
                 'queued_at' => now(),
             ]);
+
+            if (! $campaign->wasRecentlyCreated) {
+                return $campaign->load('recipients');
+            }
 
             $emails = $this->consent->confirmedEmailsForLists($lists);
 
@@ -131,20 +150,33 @@ class CampaignService
 
     private function dispatchRecipients(Campaign $campaign): void
     {
+        $recipients = $campaign->recipients()
+            ->where('status', CampaignRecipientStatus::Queued)
+            ->orderBy('id')
+            ->get();
+
+        if ($recipients->isEmpty()) {
+            $campaign->update([
+                'status' => CampaignStatus::Completed,
+                'completed_at' => now(),
+            ]);
+
+            return;
+        }
+
         $delaySeconds = 0;
         $perMinute = (int) config('mailing.throttle_per_minute', 60);
         $interval = $perMinute > 0 ? (int) ceil(60 / $perMinute) : 1;
 
-        $campaign->recipients()
-            ->where('status', CampaignRecipientStatus::Queued)
-            ->orderBy('id')
-            ->each(function (CampaignRecipient $recipient) use (&$delaySeconds, $interval) {
+        $campaign->update(['status' => CampaignStatus::Sending]);
+
+        DB::afterCommit(function () use ($recipients, &$delaySeconds, $interval) {
+            $recipients->each(function (CampaignRecipient $recipient) use (&$delaySeconds, $interval) {
                 SendCampaignRecipientJob::dispatch($recipient->id)
                     ->delay(now()->addSeconds($delaySeconds));
                 $delaySeconds += $interval;
             });
-
-        $campaign->update(['status' => CampaignStatus::Sending]);
+        });
     }
 
     /**

--- a/database/migrations/2026_08_10_000002_add_campaign_idempotency_key.php
+++ b/database/migrations/2026_08_10_000002_add_campaign_idempotency_key.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('campaigns', function (Blueprint $table) {
+            $table->string('idempotency_key')->nullable()->unique()->after('created_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('campaigns', function (Blueprint $table) {
+            $table->dropUnique(['idempotency_key']);
+            $table->dropColumn('idempotency_key');
+        });
+    }
+};

--- a/tests/Feature/MailingConsentTest.php
+++ b/tests/Feature/MailingConsentTest.php
@@ -19,6 +19,7 @@ use App\Models\User;
 use App\Notifications\ConfirmMailingListNotification;
 use App\Services\Mailing\CampaignService;
 use App\Services\Mailing\ConsentService;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
@@ -178,6 +179,121 @@ class MailingConsentTest extends TestCase
 
         $post->update(['title' => 'Changed After Publish']);
         $this->assertSame('Original Title', $campaign->fresh()->snapshot['title']);
+    }
+
+    public function test_live_campaign_uses_a_stable_database_idempotency_key(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->published()->create([
+            'author_id' => $admin->id,
+            'email_on_publish' => true,
+            'mailing_lists' => [MailingList::ApesCic->value],
+        ]);
+
+        $service = app(CampaignService::class);
+        $first = $service->createFromPublishedPost($post, $admin);
+        $second = $service->createFromPublishedPost($post->fresh(), $admin);
+
+        $this->assertNotNull($first);
+        $this->assertTrue($first->is($second));
+        $this->assertSame('post:'.$post->id.':live', $first->idempotency_key);
+        $this->assertSame(1, Campaign::query()->where('post_id', $post->id)->where('is_test', false)->count());
+    }
+
+    public function test_database_rejects_duplicate_live_campaign_idempotency_keys(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $posts = Post::factory()->count(2)->published()->create(['author_id' => $admin->id]);
+        $duplicateKey = 'post:shared:live';
+
+        Campaign::query()->create([
+            'post_id' => $posts[0]->id,
+            'created_by' => $admin->id,
+            'idempotency_key' => $duplicateKey,
+            'lists' => [MailingList::ApesCic->value],
+            'snapshot' => ['title' => 'First campaign'],
+            'status' => CampaignStatus::Draft,
+            'is_test' => false,
+        ]);
+
+        try {
+            Campaign::query()->create([
+                'post_id' => $posts[1]->id,
+                'created_by' => $admin->id,
+                'idempotency_key' => $duplicateKey,
+                'lists' => [MailingList::ApesCic->value],
+                'snapshot' => ['title' => 'Duplicate campaign'],
+                'status' => CampaignStatus::Draft,
+                'is_test' => false,
+            ]);
+            $this->fail('The database accepted a duplicate live campaign idempotency key.');
+        } catch (QueryException) {
+            $this->assertSame(1, Campaign::query()->where('idempotency_key', $duplicateKey)->count());
+        }
+    }
+
+    public function test_legacy_live_campaign_is_reused_and_backfilled_with_the_stable_key(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->published()->create([
+            'author_id' => $admin->id,
+            'email_on_publish' => true,
+            'mailing_lists' => [MailingList::ApesCic->value],
+        ]);
+        $legacy = Campaign::create([
+            'post_id' => $post->id,
+            'created_by' => $admin->id,
+            'idempotency_key' => null,
+            'lists' => [MailingList::ApesCic->value],
+            'snapshot' => ['title' => $post->title],
+            'status' => CampaignStatus::Completed,
+            'is_test' => false,
+            'queued_at' => now(),
+            'completed_at' => now(),
+        ]);
+
+        $campaign = app(CampaignService::class)->createFromPublishedPost($post, $admin);
+
+        $this->assertTrue($legacy->is($campaign));
+        $this->assertSame('post:'.$post->id.':live', $campaign->idempotency_key);
+        $this->assertSame(1, Campaign::query()->where('post_id', $post->id)->where('is_test', false)->count());
+    }
+
+    public function test_zero_recipient_live_campaign_completes_immediately(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->published()->create([
+            'author_id' => $admin->id,
+            'email_on_publish' => true,
+            'mailing_lists' => [MailingList::ApesCic->value],
+        ]);
+
+        $campaign = app(CampaignService::class)->createFromPublishedPost($post, $admin);
+
+        $this->assertNotNull($campaign);
+        $this->assertSame(CampaignStatus::Completed, $campaign->status);
+        $this->assertNotNull($campaign->completed_at);
+        $this->assertSame(0, $campaign->recipients()->count());
+    }
+
+    public function test_test_sends_remain_independent_of_live_idempotency(): void
+    {
+        Mail::fake();
+
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->create([
+            'author_id' => $admin->id,
+            'mailing_lists' => [MailingList::ApesCic->value],
+        ]);
+        $service = app(CampaignService::class);
+
+        $first = $service->createTestSend($post, $admin, 'tester@example.com');
+        $second = $service->createTestSend($post, $admin, 'tester@example.com');
+
+        $this->assertFalse($first->is($second));
+        $this->assertNull($first->idempotency_key);
+        $this->assertNull($second->idempotency_key);
+        $this->assertSame(2, Campaign::query()->where('post_id', $post->id)->where('is_test', true)->count());
     }
 
     public function test_test_send_cannot_become_live_campaign(): void

--- a/tests/Feature/PublishScheduledPostsCommandTest.php
+++ b/tests/Feature/PublishScheduledPostsCommandTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Enums\CampaignStatus;
+use App\Enums\MailingList;
 use App\Enums\PostStatus;
+use App\Models\Campaign;
 use App\Models\Post;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -23,5 +27,44 @@ class PublishScheduledPostsCommandTest extends TestCase
         $post->refresh();
         $this->assertSame(PostStatus::Published, $post->status);
         $this->assertNotNull($post->published_at);
+    }
+
+    public function test_scheduler_retries_reuse_one_campaign_and_fall_back_to_the_author(): void
+    {
+        $author = User::factory()->create();
+        $post = Post::factory()->create([
+            'author_id' => $author->id,
+            'status' => PostStatus::Scheduled,
+            'scheduled_for' => now('Europe/London')->subMinute(),
+            'email_on_publish' => true,
+            'mailing_lists' => [MailingList::ApesCic->value],
+        ]);
+
+        $this->artisan('posts:publish-scheduled')->assertSuccessful();
+        $this->artisan('posts:publish-scheduled')->assertSuccessful();
+
+        $campaign = Campaign::query()->where('post_id', $post->id)->firstOrFail();
+        $this->assertSame($author->id, $campaign->created_by);
+        $this->assertSame('post:'.$post->id.':live', $campaign->idempotency_key);
+        $this->assertSame(CampaignStatus::Completed, $campaign->status);
+        $this->assertSame(1, Campaign::query()->where('post_id', $post->id)->where('is_test', false)->count());
+    }
+
+    public function test_manual_publication_then_scheduler_does_not_duplicate_the_live_campaign(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->create([
+            'author_id' => $admin->id,
+            'status' => PostStatus::Scheduled,
+            'scheduled_for' => now('Europe/London')->subMinute(),
+            'email_on_publish' => true,
+            'mailing_lists' => [MailingList::ApesCic->value],
+        ]);
+
+        $this->actingAs($admin)->post(route('staff.posts.publish', $post))->assertRedirect();
+        $this->artisan('posts:publish-scheduled')->assertSuccessful();
+
+        $this->assertSame(PostStatus::Published, $post->fresh()->status);
+        $this->assertSame(1, Campaign::query()->where('post_id', $post->id)->where('is_test', false)->count());
     }
 }


### PR DESCRIPTION
## Linked issue

Refs #45

Issue #45 remains open until this pull request is merged, the resulting remote main tree and both post-merge CI jobs are verified, final evidence is recorded, and closure is separately authorized.

## Purpose and scope

Make live publication campaign creation idempotent so retries and concurrent publication attempts converge on one campaign per post. The change covers manual publication, scheduled publication, legacy campaign reuse, recipient dispatch timing, and the zero-recipient terminal state.

## Design decisions

- Add a nullable database-unique campaigns.idempotency_key and use the stable key post:{post_id}:live for live publication.
- Lock the post row in both manual and scheduled publication paths before creating or reusing a live campaign.
- Reuse a compatible legacy campaign when one already exists, preserving deployed data.
- Fall back to the post author when the publication actor is unavailable.
- Dispatch recipient delivery only after the surrounding transaction commits.
- Mark zero-recipient live campaigns complete immediately.
- Keep test sends independently repeatable and outside the live-publication idempotency key.
- This protects campaign creation and recipient-row dispatch; it does not claim exactly-once behavior from an external SMTP provider.

## User-visible effects

Publication retries and overlapping scheduler/manual attempts no longer create duplicate live campaigns or duplicate recipient rows. There is no intended editorial UI change.

## Documentation and changelog effects

README repository health evidence was reverified and records 2026-08-10T23:54:55+01:00. This repository has no changelog; the README continues to link the canonical GitHub Releases route.

## Local verification

- composer validate --strict --no-check-publish — passed.
- php artisan test tests/Feature/MailingConsentTest.php tests/Feature/PublishScheduledPostsCommandTest.php — passed: 18 tests, 71 assertions.
- Temporary-file SQLite migrate:fresh, target migration rollback, pending-state assertion, reapply, and applied-state assertion — passed.
- Static migration review — passed: Laravel schema operations are compatible with SQLite verification and production MySQL; no production database was contacted.
- Mail and queue review — passed: tests use fakes and no live campaign was sent.
- composer test — passed: 158 tests, 756 assertions.
- composer lint — passed.
- npm run typecheck — passed.
- npm run lint — passed.
- npm run test:frontend — passed: 4 files, 5 tests.
- npm run build — passed with the existing Vite chunk-size advisory for a chunk above 500 kB.
- composer audit --locked — passed: no known security advisories.
- npm audit — passed: 0 vulnerabilities.
- git diff --check and committed-diff whitespace review — passed.
- README/community-health review — passed: 18 Markdown files, 29 relative links, active CI badge/workflow, three issue-intake files, Issues/Discussions/Releases routes, exact live metadata/privacy/default branch/topics, production URL HTTP 200, cited #3/#10/#11 evidence, and retained apex DNS/Ghost/live-campaign/#36 boundaries.
- Complete diff, credential, private-infrastructure, personal-data, artifact, export, log, cache, and transcript scans — passed.

## CI status

Backend (PHP 8.4) and Frontend are pending at pull-request creation. Both are manually required before merge.

## Risks and rollback

The main risks are incorrect campaign reuse, suppressed delivery, or scheduler/manual locking regressions. Roll back by reverting the eventual merge commit. Any production migration or migration rollback remains a separately governed deployment operation; none was run here.

## Follow-ups

Wait for both pull-request CI jobs, obtain separate merge authorization, verify the merge and post-merge main CI, obtain separate issue-closure authorization, then begin issue #44.

## Deferred work

Deployment, production migrations, DNS or hostname changes, live campaign sending, Ghost retirement, milestone closure, branch/worktree deletion, and issue #36 are outside this pull request.