### PR TITLE
fix(account): reconcile consent after email changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ghost completed on 2026-08-06 under
 
 ## Repository status
 
-Last verified: **2026-08-10T23:54:55+01:00**.
+Last verified: **2026-08-11T10:52:34+01:00**.
 
 - `main` is the remote default branch and its CI workflow is current.
 - The public Newsroom is live at `www.apesnews.org.uk`; the apex

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\UpdateAccountRequest;
 use App\Services\Account\AccountDeletionPolicy;
+use App\Services\Account\AccountEmailChangeService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -14,7 +15,10 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class AccountController extends Controller
 {
-    public function __construct(private readonly AccountDeletionPolicy $deletionPolicy) {}
+    public function __construct(
+        private readonly AccountDeletionPolicy $deletionPolicy,
+        private readonly AccountEmailChangeService $accountUpdater,
+    ) {}
 
     public function show(Request $request): Response
     {
@@ -30,18 +34,12 @@ class AccountController extends Controller
 
     public function update(UpdateAccountRequest $request): RedirectResponse
     {
-        $user = $request->user();
-        $validated = $request->validated();
-
-        if ($validated['email'] !== $user->email) {
-            $validated['email_verified_at'] = null;
-        }
-
-        $user->update($validated);
-
-        if ($user->wasChanged('email')) {
-            $user->sendEmailVerificationNotification();
-        }
+        $this->accountUpdater->update(
+            $request->user(),
+            $request->validated(),
+            $request->ip(),
+            $request->userAgent(),
+        );
 
         return back()->with('status', 'profile-updated');
     }

--- a/app/Http/Requests/UpdateAccountRequest.php
+++ b/app/Http/Requests/UpdateAccountRequest.php
@@ -25,6 +25,8 @@ class UpdateAccountRequest extends FormRequest
                 'lowercase',
                 'email',
                 'max:255',
+                Rule::prohibitedIf(fn () => $this->user()?->auth_provider === 'cloudron_oidc'
+                    && $this->input('email') !== $this->user()?->email),
                 Rule::unique('users')->ignore($this->user()?->id),
             ],
         ];

--- a/app/Services/Account/AccountEmailChangeService.php
+++ b/app/Services/Account/AccountEmailChangeService.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace App\Services\Account;
+
+use App\Enums\ConsentAction;
+use App\Enums\MailingList;
+use App\Enums\SubscriptionStatus;
+use App\Models\ConsentEvent;
+use App\Models\MailingContact;
+use App\Models\MailingListSubscription;
+use App\Models\Suppression;
+use App\Models\User;
+use App\Notifications\ConfirmMailingListNotification;
+use App\Services\Mailing\ConsentService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class AccountEmailChangeService
+{
+    /**
+     * @param  array{name: string, email: string}  $attributes
+     */
+    public function update(User $user, array $attributes, ?string $ip = null, ?string $userAgent = null): User
+    {
+        return DB::transaction(function () use ($user, $attributes, $ip, $userAgent) {
+            $lockedUser = User::query()->lockForUpdate()->findOrFail($user->id);
+            $oldEmail = $this->normalizeEmail($lockedUser->email);
+            $newEmail = $this->normalizeEmail($attributes['email']);
+
+            if ($oldEmail === $newEmail) {
+                $lockedUser->update(['name' => $attributes['name']]);
+
+                return $lockedUser->fresh();
+            }
+
+            $oldContact = MailingContact::query()
+                ->where('email', $oldEmail)
+                ->lockForUpdate()
+                ->first();
+            $oldSuppressed = Suppression::query()
+                ->where('email', $oldEmail)
+                ->lockForUpdate()
+                ->exists();
+            $activeLists = [];
+
+            if ($oldContact) {
+                $subscriptions = $oldContact->subscriptions()->lockForUpdate()->get();
+
+                foreach ($subscriptions as $subscription) {
+                    if (! in_array($subscription->status, [SubscriptionStatus::Confirmed, SubscriptionStatus::Pending], true)) {
+                        continue;
+                    }
+
+                    if (! $oldSuppressed) {
+                        $activeLists[$subscription->list->value] = $subscription->list;
+                    }
+
+                    $subscription->update([
+                        'status' => SubscriptionStatus::Unsubscribed,
+                        'confirm_token' => null,
+                        'unsubscribed_at' => now(),
+                    ]);
+
+                    $this->recordEvent(
+                        $oldContact,
+                        $subscription->list,
+                        ConsentAction::Unsubscribed,
+                        ['account_email_changed_to' => $newEmail],
+                        $ip,
+                        $userAgent,
+                    );
+                }
+
+                Suppression::query()->firstOrCreate(
+                    ['email' => $oldEmail],
+                    ['reason' => 'account_email_change'],
+                );
+                $this->recordEvent(
+                    $oldContact,
+                    null,
+                    ConsentAction::Suppressed,
+                    ['reason' => 'account_email_change'],
+                    $ip,
+                    $userAgent,
+                );
+                $oldContact->update(['user_id' => null]);
+            }
+
+            $lockedUser->forceFill([
+                'name' => $attributes['name'],
+                'email' => $newEmail,
+                'email_verified_at' => null,
+            ])->save();
+
+            $confirmations = [];
+
+            if ($oldContact) {
+                $newContact = MailingContact::query()
+                    ->where('email', $newEmail)
+                    ->lockForUpdate()
+                    ->first();
+
+                if (! $newContact) {
+                    $newContact = MailingContact::query()->create([
+                        'email' => $newEmail,
+                        'user_id' => $lockedUser->id,
+                    ]);
+                } elseif ($newContact->user_id !== $lockedUser->id) {
+                    $newContact->update(['user_id' => $lockedUser->id]);
+                }
+
+                $newSuppressed = Suppression::query()
+                    ->where('email', $newEmail)
+                    ->lockForUpdate()
+                    ->exists();
+
+                if (! $newSuppressed) {
+                    foreach ($activeLists as $list) {
+                        $subscription = MailingListSubscription::query()
+                            ->where('mailing_contact_id', $newContact->id)
+                            ->where('list', $list->value)
+                            ->lockForUpdate()
+                            ->first();
+
+                        if ($subscription?->status === SubscriptionStatus::Unsubscribed) {
+                            continue;
+                        }
+
+                        $token = Str::random(64);
+                        $subscription ??= new MailingListSubscription([
+                            'mailing_contact_id' => $newContact->id,
+                            'list' => $list,
+                        ]);
+                        $subscription->fill([
+                            'status' => SubscriptionStatus::Pending,
+                            'confirm_token' => $token,
+                            'confirmed_at' => null,
+                            'unsubscribed_at' => null,
+                        ])->save();
+
+                        $this->recordEvent(
+                            $newContact,
+                            $list,
+                            ConsentAction::SignupRequested,
+                            ['confirm_token_issued' => true, 'account_email_changed_from' => $oldEmail],
+                            $ip,
+                            $userAgent,
+                        );
+                        $confirmations[] = [$newContact->id, $list, $token];
+                    }
+                }
+            }
+
+            $userId = $lockedUser->id;
+            DB::afterCommit(function () use ($userId, $confirmations) {
+                $updatedUser = User::query()->find($userId);
+                $updatedUser?->sendEmailVerificationNotification();
+
+                foreach ($confirmations as [$contactId, $list, $token]) {
+                    $contact = MailingContact::query()->find($contactId);
+                    $contact?->notify(new ConfirmMailingListNotification(
+                        $list,
+                        url('/mailing/confirm/'.$token),
+                    ));
+                }
+            });
+
+            return $lockedUser->fresh();
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function recordEvent(
+        MailingContact $contact,
+        ?MailingList $list,
+        ConsentAction $action,
+        array $evidence,
+        ?string $ip,
+        ?string $userAgent,
+    ): void {
+        ConsentEvent::query()->create([
+            'mailing_contact_id' => $contact->id,
+            'email' => $contact->email,
+            'list' => $list,
+            'action' => $action,
+            'source' => 'account_email_change',
+            'wording_version' => ConsentService::WORDING_VERSION,
+            'evidence' => $evidence,
+            'ip_address' => $ip,
+            'user_agent' => $userAgent,
+            'created_at' => now(),
+        ]);
+    }
+
+    private function normalizeEmail(string $email): string
+    {
+        return Str::lower(trim($email));
+    }
+}

--- a/tests/Feature/AccountEmailChangeTest.php
+++ b/tests/Feature/AccountEmailChangeTest.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ConsentAction;
+use App\Enums\MailingList;
+use App\Enums\SubscriptionStatus;
+use App\Models\MailingContact;
+use App\Models\MailingListSubscription;
+use App\Models\Suppression;
+use App\Models\User;
+use App\Notifications\ConfirmMailingListNotification;
+use App\Services\Account\AccountEmailChangeService;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class AccountEmailChangeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_email_change_withdraws_old_active_lists_and_requires_fresh_confirmation(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'old@example.com']);
+        $oldContact = MailingContact::factory()->create([
+            'email' => 'old@example.com',
+            'user_id' => $user->id,
+        ]);
+        $this->subscription($oldContact, MailingList::ApesCic, SubscriptionStatus::Confirmed, now());
+        $this->subscription($oldContact, MailingList::ApesShelterRescue, SubscriptionStatus::Pending);
+        $this->subscription($oldContact, MailingList::ApesPetCareClinic, SubscriptionStatus::Unsubscribed);
+
+        $this->actingAs($user)->patch(route('account.update'), [
+            'name' => $user->name,
+            'email' => 'new@example.com',
+        ])->assertRedirect();
+
+        $this->assertSame('new@example.com', $user->fresh()->email);
+        $this->assertNull($oldContact->fresh()->user_id);
+        $this->assertDatabaseHas('suppressions', [
+            'email' => 'old@example.com',
+            'reason' => 'account_email_change',
+        ]);
+
+        foreach ([MailingList::ApesCic, MailingList::ApesShelterRescue] as $list) {
+            $this->assertDatabaseHas('mailing_list_subscriptions', [
+                'mailing_contact_id' => $oldContact->id,
+                'list' => $list->value,
+                'status' => SubscriptionStatus::Unsubscribed->value,
+            ]);
+            $this->assertDatabaseHas('consent_events', [
+                'email' => 'old@example.com',
+                'list' => $list->value,
+                'action' => ConsentAction::Unsubscribed->value,
+                'source' => 'account_email_change',
+            ]);
+        }
+
+        $newContact = MailingContact::query()->where('email', 'new@example.com')->firstOrFail();
+        $this->assertSame($user->id, $newContact->user_id);
+        $this->assertSame(2, $newContact->subscriptions()->count());
+        $this->assertDatabaseMissing('mailing_list_subscriptions', [
+            'mailing_contact_id' => $newContact->id,
+            'list' => MailingList::ApesPetCareClinic->value,
+        ]);
+
+        foreach ([MailingList::ApesCic, MailingList::ApesShelterRescue] as $list) {
+            $subscription = $newContact->subscriptions()->where('list', $list->value)->firstOrFail();
+            $this->assertSame(SubscriptionStatus::Pending, $subscription->status);
+            $this->assertNull($subscription->confirmed_at);
+            $this->assertNotNull($subscription->confirm_token);
+            $this->assertDatabaseHas('consent_events', [
+                'email' => 'new@example.com',
+                'list' => $list->value,
+                'action' => ConsentAction::SignupRequested->value,
+                'source' => 'account_email_change',
+            ]);
+        }
+
+        Notification::assertSentToTimes($newContact, ConfirmMailingListNotification::class, 2);
+        Notification::assertSentTo($user, VerifyEmail::class);
+    }
+
+    public function test_email_change_does_not_create_mailing_state_when_old_address_had_none(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'absent@example.com']);
+
+        $this->actingAs($user)->patch(route('account.update'), [
+            'name' => $user->name,
+            'email' => 'new-absent@example.com',
+        ])->assertRedirect();
+
+        $this->assertDatabaseMissing('mailing_contacts', ['email' => 'new-absent@example.com']);
+        Notification::assertSentTo($user, VerifyEmail::class);
+        Notification::assertSentTimes(ConfirmMailingListNotification::class, 0);
+    }
+
+    public function test_suppressed_old_address_does_not_resurrect_stale_active_lists(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'suppressed@example.com']);
+        $oldContact = MailingContact::factory()->create([
+            'email' => 'suppressed@example.com',
+            'user_id' => $user->id,
+        ]);
+        $this->subscription($oldContact, MailingList::ApesCic, SubscriptionStatus::Confirmed, now());
+        Suppression::create(['email' => 'suppressed@example.com', 'reason' => 'objection']);
+
+        $this->actingAs($user)->patch(route('account.update'), [
+            'name' => $user->name,
+            'email' => 'replacement@example.com',
+        ])->assertRedirect();
+
+        $newContact = MailingContact::query()->where('email', 'replacement@example.com')->firstOrFail();
+        $this->assertSame(0, $newContact->subscriptions()->count());
+        Notification::assertNotSentTo($newContact, ConfirmMailingListNotification::class);
+    }
+
+    public function test_existing_unsubscribed_new_address_is_not_resurrected(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'source@example.com']);
+        $oldContact = MailingContact::factory()->create([
+            'email' => 'source@example.com',
+            'user_id' => $user->id,
+        ]);
+        $this->subscription($oldContact, MailingList::ApesCic, SubscriptionStatus::Confirmed, now());
+
+        $newContact = MailingContact::factory()->create(['email' => 'withdrawn@example.com']);
+        $newSubscription = $this->subscription(
+            $newContact,
+            MailingList::ApesCic,
+            SubscriptionStatus::Unsubscribed,
+        );
+
+        $this->actingAs($user)->patch(route('account.update'), [
+            'name' => $user->name,
+            'email' => 'withdrawn@example.com',
+        ])->assertRedirect();
+
+        $this->assertSame(SubscriptionStatus::Unsubscribed, $newSubscription->fresh()->status);
+        Notification::assertNotSentTo($newContact, ConfirmMailingListNotification::class);
+    }
+
+    public function test_suppressed_new_address_does_not_receive_recreated_subscriptions(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'source@example.com']);
+        $oldContact = MailingContact::factory()->create([
+            'email' => 'source@example.com',
+            'user_id' => $user->id,
+        ]);
+        $this->subscription($oldContact, MailingList::ApesCic, SubscriptionStatus::Confirmed, now());
+        Suppression::query()->create([
+            'email' => 'blocked@example.com',
+            'reason' => 'recipient_objection',
+        ]);
+
+        $this->actingAs($user)->patch(route('account.update'), [
+            'name' => $user->name,
+            'email' => 'blocked@example.com',
+        ])->assertRedirect();
+
+        $newContact = MailingContact::query()->where('email', 'blocked@example.com')->firstOrFail();
+        $this->assertSame($user->id, $newContact->user_id);
+        $this->assertSame(0, $newContact->subscriptions()->count());
+        Notification::assertNotSentTo($newContact, ConfirmMailingListNotification::class);
+        Notification::assertSentTo($user, VerifyEmail::class);
+    }
+
+    public function test_outer_transaction_rollback_restores_consent_state_and_discards_notifications(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'rollback-old@example.com']);
+        $oldContact = MailingContact::factory()->create([
+            'email' => 'rollback-old@example.com',
+            'user_id' => $user->id,
+        ]);
+        $oldSubscription = $this->subscription(
+            $oldContact,
+            MailingList::ApesCic,
+            SubscriptionStatus::Confirmed,
+            now(),
+        );
+
+        try {
+            DB::transaction(function () use ($user) {
+                app(AccountEmailChangeService::class)->update(
+                    $user,
+                    ['name' => $user->name, 'email' => 'rollback-new@example.com'],
+                    '127.0.0.1',
+                    'account-email-change-test',
+                );
+
+                throw new \RuntimeException('Force the outer account update to roll back.');
+            });
+
+            $this->fail('The outer transaction unexpectedly committed.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('Force the outer account update to roll back.', $exception->getMessage());
+        }
+
+        $this->assertSame('rollback-old@example.com', $user->fresh()->email);
+        $this->assertSame($user->id, $oldContact->fresh()->user_id);
+        $this->assertSame(SubscriptionStatus::Confirmed, $oldSubscription->fresh()->status);
+        $this->assertDatabaseMissing('mailing_contacts', ['email' => 'rollback-new@example.com']);
+        $this->assertDatabaseMissing('suppressions', ['email' => 'rollback-old@example.com']);
+        $this->assertDatabaseMissing('consent_events', ['source' => 'account_email_change']);
+        Notification::assertNothingSent();
+    }
+
+    public function test_oidc_managed_email_cannot_be_changed_directly(): void
+    {
+        $user = User::factory()->staff()->create(['email' => 'staff@example.com']);
+
+        $this->actingAs($user)->patch(route('account.update'), [
+            'name' => $user->name,
+            'email' => 'changed@example.com',
+        ])->assertSessionHasErrors('email');
+
+        $this->assertSame('staff@example.com', $user->fresh()->email);
+    }
+
+    private function subscription(
+        MailingContact $contact,
+        MailingList $list,
+        SubscriptionStatus $status,
+        mixed $confirmedAt = null,
+    ): MailingListSubscription {
+        return MailingListSubscription::create([
+            'mailing_contact_id' => $contact->id,
+            'list' => $list,
+            'status' => $status,
+            'confirm_token' => $status === SubscriptionStatus::Pending ? str_repeat('a', 64) : null,
+            'confirmed_at' => $confirmedAt,
+            'unsubscribed_at' => $status === SubscriptionStatus::Unsubscribed ? now() : null,
+        ]);
+    }
+}


### PR DESCRIPTION
## Linked issue

Refs #44

## Purpose and scope

Reconcile local account email changes with the mailing-consent ledger so the old address cannot remain active while the account moves to a new address. This PR is limited to the account update controller/request, a transactional email-change service, focused regression tests, and the repository-health timestamp.

## Design decisions

- Lock the user and affected mailing records inside one database transaction.
- Withdraw confirmed and pending old-address subscriptions, record durable account_email_change consent evidence, suppress the old address, and detach its contact from the account.
- Recreate only formerly active list selections at the normalized new address as pending, with fresh confirmation tokens and no transferred confirmation timestamps.
- Respect existing unsubscribe and suppression state at the new address.
- Dispatch account verification and mailing confirmation notifications only after the outermost transaction commits.
- Keep Cloudron OIDC-managed email immutable.
- Preserve the existing #47 AccountDeletionPolicy injection, server-derived deletion eligibility, and row-locked/refusing deletion path.

## User-visible effects

A local user changing their account email must reconfirm any previously active mailing-list choices at the new address. The old address is unsubscribed and suppressed. OIDC-managed users still cannot edit their managed email. Account deletion behavior is unchanged.

## Documentation and changelog

README.md records the completed repository-health review at 2026-08-11T10:52:34+01:00. This repository has no changelog; no release history was fabricated. The README continues to identify apex DNS, live campaign sends, Ghost retirement, and issue #36 as separately governed.

## Local verification

- composer validate --strict --no-check-publish — passed
- php artisan test tests/Feature/AccountEmailChangeTest.php tests/Feature/AccountTest.php — passed: 16 tests, 168 assertions
- composer test — passed: 165 tests, 803 assertions
- composer lint — passed
- npm run typecheck — passed
- npm run lint — passed
- npm run test:frontend — passed: 4 test files, 5 tests
- npm run build — passed; known Vite chunk-size advisory recurred for the 903.20 kB application bundle
- composer audit --locked — passed: no security advisories
- npm audit — passed: 0 vulnerabilities
- README/community-health review — passed: 18 Markdown files, 29 relative links, active CI workflow, issue forms/support routes, exact live repository metadata, and production HTTP 200
- Cited #3/#10/#11 evidence review — passed; the documentation does not overstate DNS, Ghost-retirement, or live-send status
- git diff --check origin/main...HEAD — passed
- git diff --cached --check — passed
- Added-line credential and artifact/status scans — passed

## CI status

GitHub PR CI passed: [Backend (PHP 8.4)](https://github.com/APESCIC/APES-Newsroom/actions/runs/31482143381/job/93749313895) and [Frontend](https://github.com/APESCIC/APES-Newsroom/actions/runs/31482143381/job/93749313809) both completed successfully. The repository remains manually gated, and a separate merge authorization is still required.

## Risks and rollback

The main risks are consent-state reconciliation under concurrent updates and notification timing around nested transactions. Focused rollback, suppression, prior-unsubscribe, and after-commit tests cover those paths. If a regression is found after a separately authorized merge, revert the merge commit; this PR introduces no schema migration and performs no production mutation by itself.

## Follow-ups

After both PR CI jobs pass, obtain separate authorization before any merge. Issues #43 and #46 remain later, separately gated phases.

## Deferred work

No deployment workflow, production migration, DNS or hostname change, live campaign send, Ghost retirement, issue #36 work, branch deletion, or worktree removal is included.