### PR TITLE
feat(#10): publish APES CIC public contact details

### DIFF
--- a/resources/js/Components/Layout/ProtectedEmail.tsx
+++ b/resources/js/Components/Layout/ProtectedEmail.tsx
@@ -1,0 +1,16 @@
+const EMAIL_LOCAL = 'info';
+const EMAIL_DOMAIN = ['apes', 'org', 'uk'].join('.');
+
+function publicEmail(): string {
+    return `${EMAIL_LOCAL}@${EMAIL_DOMAIN}`;
+}
+
+export default function ProtectedEmail({ className }: { className?: string }) {
+    const address = publicEmail();
+
+    return (
+        <a href={`mailto:${address}`} rel="nofollow" className={className}>
+            {address}
+        </a>
+    );
+}

--- a/resources/js/Components/Layout/SiteFooter.tsx
+++ b/resources/js/Components/Layout/SiteFooter.tsx
@@ -1,13 +1,29 @@
 import { Link } from '@inertiajs/react';
+import { ORG_PHONE_DISPLAY, ORG_PHONE_TEL, ORG_POSTAL_ADDRESS } from '../../organisationContact';
 import ApesLogo from '../Brand/ApesLogo';
+import ProtectedEmail from './ProtectedEmail';
+
+const contactLinkClassName =
+    'inline-flex min-h-11 min-w-11 items-center hover:text-body';
 
 export default function SiteFooter() {
     return (
         <footer className="border-t border-border bg-white py-10">
-            <div className="mx-auto flex max-w-public flex-col gap-6 px-5 sm:px-6 md:flex-row md:items-center md:justify-between">
+            <div className="mx-auto flex max-w-public flex-col gap-6 px-5 sm:px-6 md:flex-row md:items-start md:justify-between">
                 <Link href="/" aria-label="APES Newsroom home" className="inline-flex w-fit rounded-control">
                     <ApesLogo variant="footer" alt="" className="h-16 w-16 object-contain" />
                 </Link>
+                <div className="text-sm not-italic text-muted">
+                    <address className="not-italic">{ORG_POSTAL_ADDRESS}</address>
+                    <p className="mt-1">
+                        <a href={`tel:${ORG_PHONE_TEL}`} className={contactLinkClassName}>
+                            {ORG_PHONE_DISPLAY}
+                        </a>
+                    </p>
+                    <p>
+                        <ProtectedEmail className={contactLinkClassName} />
+                    </p>
+                </div>
                 <nav aria-label="Legal and subscriptions">
                     <ul className="flex flex-wrap gap-x-6 gap-y-3 text-sm text-muted">
                         <li><Link href="/legal/privacy" className="inline-flex min-h-11 min-w-11 items-center justify-center hover:text-body">Privacy</Link></li>

--- a/resources/js/Pages/Legal/Privacy.tsx
+++ b/resources/js/Pages/Legal/Privacy.tsx
@@ -1,5 +1,7 @@
 import { Head, Link } from '@inertiajs/react';
+import ProtectedEmail from '../../Components/Layout/ProtectedEmail';
 import PublicLayout from '../../Components/Layout/PublicLayout';
+import { ORG_PHONE_DISPLAY, ORG_PHONE_TEL, ORG_POSTAL_ADDRESS } from '../../organisationContact';
 
 export default function Privacy() {
     return (
@@ -25,7 +27,14 @@ export default function Privacy() {
                     mailing preference controls.
                 </p>
                 <h2>Contact</h2>
-                <p>Privacy questions: use the contact channels published on the APES CIC website.</p>
+                <p>Privacy questions: write to APES CIC at the address below, call, or email.</p>
+                <address className="not-italic">
+                    {ORG_POSTAL_ADDRESS}
+                    <br />
+                    <a href={`tel:${ORG_PHONE_TEL}`}>{ORG_PHONE_DISPLAY}</a>
+                    <br />
+                    <ProtectedEmail />
+                </address>
             </main>
         </PublicLayout>
     );

--- a/resources/js/__tests__/home.test.tsx
+++ b/resources/js/__tests__/home.test.tsx
@@ -5,6 +5,7 @@ import { formatStoryDate } from '../Components/Home/DeskPanel';
 import Home from '../Pages/home';
 import { setMockPage } from '../test/inertia';
 import appCss from '../../css/app.css?raw';
+import protectedEmailSource from '../Components/Layout/ProtectedEmail.tsx?raw';
 
 describe('Direction A public homepage', () => {
     let desktopMatches: boolean;
@@ -192,5 +193,15 @@ describe('Direction A public homepage', () => {
         for (const link of within(footerNavigation).getAllByRole('link')) {
             expect(link).toHaveClass('inline-flex', 'min-h-11', 'min-w-11', 'items-center', 'justify-center');
         }
+
+        const footer = screen.getByRole('contentinfo');
+        expect(footer).toHaveTextContent('40 Morris Street, St Helens, Merseyside, WA9 3EN');
+        expect(within(footer).getByRole('link', { name: '01744 374 015' })).toHaveAttribute('href', 'tel:+441744374015');
+
+        const assembledEmail = ['info', '@', ['apes', 'org', 'uk'].join('.')].join('');
+        const emailLink = within(footer).getByRole('link', { name: assembledEmail });
+        expect(emailLink).toHaveAttribute('href', `mailto:${assembledEmail}`);
+        expect(emailLink).toHaveAttribute('rel', 'nofollow');
+        expect(protectedEmailSource).not.toContain(assembledEmail);
     });
 });

--- a/resources/js/organisationContact.ts
+++ b/resources/js/organisationContact.ts
@@ -1,0 +1,3 @@
+export const ORG_POSTAL_ADDRESS = '40 Morris Street, St Helens, Merseyside, WA9 3EN';
+export const ORG_PHONE_DISPLAY = '01744 374 015';
+export const ORG_PHONE_TEL = '+441744374015';

--- a/resources/views/mail/campaign-post-summary.blade.php
+++ b/resources/views/mail/campaign-post-summary.blade.php
@@ -19,6 +19,7 @@ Thanks,<br>
 {{ config('app.name') }}
 
 <x-mail::subcopy>
-APES CIC · Manage your [preferences]({{ $preferencesUrl }}) or [unsubscribe]({{ $unsubscribeUrl }}).
+APES CIC · 40 Morris Street, St Helens, Merseyside, WA9 3EN · 01744 374 015<br>
+Manage your [preferences]({{ $preferencesUrl }}) or [unsubscribe]({{ $unsubscribeUrl }}).
 </x-mail::subcopy>
 </x-mail::message>


### PR DESCRIPTION
## Summary
- Publish the registered office and phone on the public footer, privacy notice, and campaign email subcopy.
- Assemble `info@apes.org.uk` at render time as a `rel=nofollow` mailto (not in Inertia page props or Blade).

## Test plan
- [ ] Footer shows 40 Morris Street, St Helens, Merseyside, WA9 3EN
- [ ] Phone link is `tel:+441744374015`
- [ ] Email link is mailto with `rel=nofollow`
- [ ] Privacy notice shows the same contact block
- [ ] Campaign email subcopy includes address and phone, not a Blade mailto