### PR TITLE
feat(#53): implement Magazine Bold Grid theme across full product

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -44,6 +44,8 @@ class HomeController extends Controller
             'channel_slug' => $post->channel->slug(),
             'author' => $post->author->name,
             'published_at' => $post->published_at?->toIso8601String(),
+            'hero_image' => $post->hero_image,
+            'hero_image_alt' => $post->hero_image_alt,
         ];
     }
 }

--- a/docs/design/component-inventory.md
+++ b/docs/design/component-inventory.md
@@ -1,8 +1,7 @@
 # APES Newsroom — Component inventory
 
-> **Status:** Direction A approved under #31. Homepage, admin moderation, and
-> staff posts components are implemented under #32; remaining rows describe
-> established or later epic surfaces.
+> **Status:** Direction A approved under #31/#32. Direction B (Magazine Bold
+> Grid) components implemented under #53.
 
 ## Direction A layout and content
 
@@ -12,8 +11,10 @@
 | `AccountMenu` | Login/Register or Account disclosure with Profile, Admin, Staff, Sign out; Escape closes only this disclosure and restores its trigger, while breakpoint changes close a presentation that becomes hidden and transfer its focus to visible navigation | guest, public, staff, admin, nested mobile disclosure, breakpoint change |
 | `SiteFooter` | Dedicated 64px brand mark and privacy, cookies, rights, mailing links with minimum 44×44px touch targets | default |
 | `DeskPanel` | Featured-story media panel, channel, headline, excerpt, byline/London publication date and story action | empty, populated |
-| `ChannelTrailTile` | Labelled line icon, channel name, description and channel link | default, focus |
-| `RecentStoryCard` | Source-backed channel treatment, title, nullable excerpt and semantic Europe/London publication time | default, missing metadata |
+| `ChannelTrailTile` | Labelled line icon, channel name, description and channel link with `.channel-block` mist background and left accent stripe | default, focus |
+| `RecentStoryCard` | Source-backed channel treatment, title, nullable excerpt, hero image and semantic Europe/London publication time | default, lead, missing metadata |
+| `AccountLayout` | Public chrome wrapper with centred `.form-panel` card for account and mailing settings | default, status messages |
+| `AuthCard` | Compact logo header and centred form card for authentication pages | login, register, password reset |
 | `WorkspaceLayout` | Dark role-labelled rail, account controls, light task canvas, measured skip-link offset and scrollable modal mobile drawer with contained focus, inert and scroll-locked background, and automatic close to the active desktop destination at the desktop breakpoint | staff, admin, wrapped task header, short viewport, breakpoint change |
 | `LineIcon` | First-party current-colour line icons without emoji dependencies | decorative |
 | `ApesLogo` | Unfiltered horizontal, masthead, footer, square, or compact APES artwork; the masthead uses a deterministic tight crop, the footer uses a 64px derivative, and square placement uses 384/768 WebP sources with PNG fallback | per placement, responsive |

--- a/docs/design/direction-b-ui.md
+++ b/docs/design/direction-b-ui.md
@@ -1,0 +1,74 @@
+# Direction B UI — Magazine Bold Grid
+
+Status: stakeholder-approved on 2026-08-24 under
+[issue #36](https://github.com/APESCIC/APES-Newsroom/issues/36).
+Implementation tracked under
+[issue #53](https://github.com/APESCIC/APES-Newsroom/issues/53).
+
+## Selected character
+
+Direction B is a logo-led Magazine Bold Grid evolution of Direction A. Public
+pages use asymmetric editorial grids, stronger headline hierarchy, and bold
+channel colour blocks while remaining calm, credible, and newsroom-first.
+Authenticated workspaces retain the same brand ink, teal and typography but
+prioritise dense, calm task completion without asymmetric editorial layouts.
+
+The supplied horizontal, square and compact APES logo files are the only brand
+sources. Their artwork remains unchanged without filters or recolouring. No frog
+mascot artwork is included in this direction.
+
+Instrument Sans Variable 5.3.0 remains self-hosted from the application bundle.
+Direction B uses supported weights 400–700; display headlines use 700 at larger
+scale via the `.display-headline` component class.
+
+## Page decisions
+
+### Homepage
+
+- Asymmetric 7/5 hero: bold featured story with `.editorial-rule` accent on the
+  left; featured hero image or compact mission panel on the right.
+- Three equal channel entry cards with full mist colour blocks and left accent
+  stripes (APES CIC, Shelter & Rescue, Pet Care Clinic).
+- Recent stories use an editorial grid with a lead card spanning two columns on
+  desktop; hero images render when available with icon placeholder fallback.
+- Public navigation and account actions remain source- and role-aware.
+
+### Articles
+
+- Stronger display headline scale and channel badge via `channelMeta`.
+- Long-form reading measure stays ~720px with existing `.prose` styling.
+
+### Channels, archives, search, legal
+
+- Token migration from legacy `neutral-*` classes to Direction B tokens.
+- Channel pages use a channel-coloured header block.
+
+### Account and mailing
+
+- New `AccountLayout` wraps personal settings under public chrome with a centred
+  `.form-panel` card.
+- Consent, privacy, and moderation status copy preserved.
+
+### Authentication
+
+- New `AuthCard` component with compact logo and token-based form styling.
+
+### Admin moderation and staff editorial desk
+
+- Shared workspace shell unchanged in information architecture.
+- Minimal token alignment only; no asymmetric grids or display headlines.
+
+## Accessibility and brand constraints
+
+- Target WCAG 2.2 AA contrast.
+- Visible focus intent and complete keyboard-operable navigation patterns.
+- Maintain 44×44px minimum targets.
+- Never use colour alone for channel, moderation, or publishing status.
+- Respect `prefers-reduced-motion`.
+- Preserve the supplied logo aspect ratios and artwork exactly.
+
+## Out of scope
+
+Application routes, permissions, moderation actions, mailing consent behaviour,
+frog mascot artwork, logo modification, deployment, and production cutover are
+not authorized by this design direction.

--- a/docs/design/tokens.md
+++ b/docs/design/tokens.md
@@ -1,7 +1,8 @@
-# APES Newsroom — Direction A design tokens
+# APES Newsroom — design tokens
 
-> **Status:** Approved with the complete Direction A mock-up set under issue
-> #31 and implemented for homepage, admin moderation, and staff posts under #32.
+> **Status:** Direction A approved under #31/#32. Direction B (Magazine Bold
+> Grid) approved under #36 and implemented under #53; extends these tokens
+> with display and editorial component classes.
 
 ## Brand direction
 
@@ -49,6 +50,17 @@ use the supported 700 weight and compact line height. Body and UI text use
 400–600 weight, with 16px primary reading text and 14px minimum compact
 metadata. Article measure is 65–72 characters.
 
+### Direction B display scale
+
+| Class | Scale | Usage |
+| --- | --- | --- |
+| `.display-headline` | 2.25–3.75rem (36–60px) | Homepage hero and article titles |
+| `.eyebrow` | 0.75rem uppercase | Channel and section labels |
+| Section headings | 1.5rem (24px) bold | Recent stories, archive pages |
+
+Responsive display headlines step from `text-4xl` to `text-6xl` at `sm`
+breakpoint with `leading-[1.05]` and `text-brand-ink`.
+
 ## Spacing, radius and elevation
 
 - 4px base grid; primary gaps are 16, 24, 32 and 48px.
@@ -67,9 +79,27 @@ metadata. Article measure is 65–72 characters.
 - Disable non-essential motion for `prefers-reduced-motion`.
 - Maintain WCAG 2.2 AA contrast and reflow at 200% zoom.
 
+## Direction B component classes
+
+| Class | Purpose |
+| --- | --- |
+| `.display-headline` | Hero-scale bold headlines |
+| `.editorial-rule` | 4px teal decorative left stripe on editorial blocks |
+| `.channel-block` | Full mist background with channel-coloured left border |
+| `.form-panel` | White card on page-tint for account/mailing/auth forms |
+| `.status-badge-success` | Published/approved state pill |
+| `.status-badge-warning` | In-review/needs-attention state pill |
+| `.status-badge-danger` | Rejection/destructive state pill |
+
+## Editorial grid
+
+- Homepage lead story card spans 2 columns on `md+` breakpoints.
+- Channel cards remain three equal columns on desktop; single column on mobile.
+- Grid reflows to single column below 768px for accessibility at 200% zoom.
+
 ## Page-shell mapping
 
-- Public: dark brand masthead, light editorial content and a restrained legal
-  footer.
+- Public: dark brand masthead with teal bottom rule, light editorial content
+  and a restrained legal footer.
 - Staff/admin: dark workspace rail and light working canvas. Workspace links
   remain role-aware; the visual refresh does not broaden authorization.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -168,6 +168,89 @@
         font-size: 0.75rem;
         font-weight: 700;
     }
+
+    .display-headline {
+        font-size: 2.25rem;
+        line-height: 1.05;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        color: var(--color-brand-ink);
+    }
+
+    @media (min-width: 640px) {
+        .display-headline {
+            font-size: 3.75rem;
+        }
+    }
+
+    .editorial-rule {
+        border-left: 4px solid var(--color-brand-teal);
+        padding-left: 1.5rem;
+    }
+
+    .channel-block {
+        display: flex;
+        min-height: 11rem;
+        flex-direction: column;
+        border-radius: var(--radius-card);
+        border: 1px solid var(--color-border);
+        border-left-width: 4px;
+        padding: 1.5rem;
+        transition: transform 150ms ease, box-shadow 150ms ease;
+    }
+
+    .channel-block:hover {
+        transform: translateY(-0.25rem);
+        box-shadow: var(--shadow-elevated);
+    }
+
+    .form-panel {
+        border-radius: var(--radius-card);
+        border: 1px solid var(--color-border);
+        background: var(--color-surface);
+        padding: 2rem;
+    }
+
+    .form-input {
+        display: block;
+        width: 100%;
+        border-radius: var(--radius-control);
+        border: 1px solid var(--color-border);
+        background: var(--color-surface);
+        padding: 0.625rem 0.75rem;
+        font-size: 0.875rem;
+        color: var(--color-body);
+    }
+
+    .form-input:focus {
+        border-color: var(--color-teal-deep);
+        outline: none;
+    }
+
+    .status-badge-success,
+    .status-badge-warning,
+    .status-badge-danger {
+        display: inline-flex;
+        border-radius: 999px;
+        padding: 0.25rem 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 700;
+    }
+
+    .status-badge-success {
+        background: var(--color-success-mist);
+        color: var(--color-success);
+    }
+
+    .status-badge-warning {
+        background: var(--color-warning-mist);
+        color: var(--color-warning);
+    }
+
+    .status-badge-danger {
+        background: #fce8e8;
+        color: var(--color-danger);
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -183,7 +266,7 @@
 
 .prose {
     line-height: 1.7;
-    color: var(--color-neutral-900);
+    color: var(--color-body);
 }
 
 .prose p,

--- a/resources/js/Components/Auth/AuthCard.tsx
+++ b/resources/js/Components/Auth/AuthCard.tsx
@@ -1,0 +1,28 @@
+import { type ReactNode } from 'react';
+import { Link } from '@inertiajs/react';
+import ApesLogo from '../Brand/ApesLogo';
+
+type AuthCardProps = {
+    title: string;
+    description?: string;
+    children: ReactNode;
+};
+
+export default function AuthCard({ title, description, children }: AuthCardProps) {
+    return (
+        <div className="flex min-h-screen flex-col bg-page-tint">
+            <header className="border-b border-border bg-white px-5 py-4 sm:px-6">
+                <Link href="/" className="inline-flex">
+                    <ApesLogo variant="compact" className="h-10 w-auto object-contain" alt="APES Newsroom home" />
+                </Link>
+            </header>
+            <main id="main-content" className="mx-auto flex w-full max-w-md flex-1 flex-col justify-center px-5 py-12 sm:px-6">
+                <div className="form-panel">
+                    <h1 className="text-2xl font-bold text-body">{title}</h1>
+                    {description && <p className="mt-2 text-sm text-muted">{description}</p>}
+                    <div className="mt-6">{children}</div>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/resources/js/Components/Home/ChannelTrailTile.tsx
+++ b/resources/js/Components/Home/ChannelTrailTile.tsx
@@ -9,15 +9,20 @@ export default function ChannelTrailTile({ slug }: { slug: string }) {
         return null;
     }
 
+    const mistClass =
+        meta.accent === 'apes' ? 'bg-apes-mist border-apes-primary' :
+        meta.accent === 'shelter' ? 'bg-shelter-mist border-shelter-accent' :
+        'bg-clinic-mist border-clinic-accent';
+
     return (
         <Link
             href={`/${canonicalChannelSlug(slug)}`}
-            className="group flex min-h-44 flex-col rounded-card border border-border bg-white p-6 transition-transform hover:-translate-y-1 hover:shadow-elevated"
+            className={`channel-block group ${mistClass}`}
         >
-            <span className={`flex h-12 w-12 items-center justify-center rounded-control ${meta.mediaClass}`}>
+            <span className={`flex h-12 w-12 items-center justify-center rounded-control bg-white/60 ${meta.textClass}`}>
                 <LineIcon name={meta.icon} className="h-7 w-7" />
             </span>
-            <span className="mt-4 text-lg font-bold text-body">{meta.label}</span>
+            <span className="mt-4 text-xl font-bold text-body">{meta.label}</span>
             <span className="mt-2 text-sm leading-6 text-muted">{meta.description}</span>
         </Link>
     );

--- a/resources/js/Components/Home/DeskPanel.tsx
+++ b/resources/js/Components/Home/DeskPanel.tsx
@@ -10,6 +10,8 @@ export type PostCard = {
     channel_slug: string;
     author: string;
     published_at: string | null;
+    hero_image?: string | null;
+    hero_image_alt?: string | null;
 };
 
 export function formatStoryDate(value: string | null) {
@@ -28,10 +30,10 @@ export function formatStoryDate(value: string | null) {
 export default function DeskPanel({ featured }: { featured?: PostCard }) {
     if (!featured) {
         return (
-            <section className="flex min-h-80 items-center">
+            <section className="editorial-rule flex min-h-80 items-center">
                 <div>
                     <p className="eyebrow">Featured story</p>
-                    <h1 className="mt-3 text-3xl font-bold tracking-tight text-brand-ink">News from across APES</h1>
+                    <h1 className="display-headline mt-3">News from across APES</h1>
                     <p className="mt-4 max-w-xl text-muted">No published stories yet. Please check back soon.</p>
                 </div>
             </section>
@@ -42,12 +44,12 @@ export default function DeskPanel({ featured }: { featured?: PostCard }) {
     const published = formatStoryDate(featured.published_at);
 
     return (
-        <article className="max-w-[45rem]">
+        <article className="editorial-rule max-w-[45rem]">
             <p className={`eyebrow flex items-center gap-2 ${meta?.textClass ?? 'text-teal-deep'}`}>
                 <LineIcon name={meta?.icon ?? 'document'} className="h-4 w-4" />
                 {featured.channel}
             </p>
-            <h1 className="mt-4 text-4xl leading-[1.1] font-bold tracking-tight text-body sm:text-5xl">
+            <h1 className="display-headline mt-4">
                 <Link href={`/articles/${featured.slug}`} className="hover:text-teal-deep hover:underline">
                     {featured.title}
                 </Link>

--- a/resources/js/Components/Home/RecentStoryCard.tsx
+++ b/resources/js/Components/Home/RecentStoryCard.tsx
@@ -3,24 +3,46 @@ import { channelMeta } from '../../channelMeta';
 import LineIcon from '../Icons/LineIcon';
 import { formatStoryDate, type PostCard } from './DeskPanel';
 
-export default function RecentStoryCard({ post }: { post: PostCard }) {
+type RecentStoryCardProps = {
+    post: PostCard;
+    variant?: 'default' | 'lead';
+};
+
+export default function RecentStoryCard({ post, variant = 'default' }: RecentStoryCardProps) {
     const meta = channelMeta(post.channel_slug);
     const published = formatStoryDate(post.published_at);
+    const isLead = variant === 'lead';
 
     return (
-        <article className="group">
-            <div className={`flex aspect-video items-center justify-center overflow-hidden rounded-control border border-border ${meta?.mediaClass ?? 'bg-brand-mist text-teal-deep'}`}>
-                <LineIcon name={meta?.icon ?? 'document'} className="h-16 w-16" />
+        <article className={`group ${isLead ? 'md:col-span-2' : ''}`}>
+            <div
+                className={`flex items-center justify-center overflow-hidden rounded-control border border-border ${
+                    isLead ? 'aspect-[16/9]' : 'aspect-video'
+                } ${meta?.mediaClass ?? 'bg-brand-mist text-teal-deep'}`}
+            >
+                {post.hero_image ? (
+                    <img
+                        src={post.hero_image}
+                        alt={post.hero_image_alt ?? ''}
+                        className="h-full w-full object-cover"
+                        loading="lazy"
+                        decoding="async"
+                    />
+                ) : (
+                    <LineIcon name={meta?.icon ?? 'document'} className={isLead ? 'h-20 w-20' : 'h-16 w-16'} />
+                )}
             </div>
             <span className={`mt-4 inline-flex rounded-control px-2 py-1 text-[0.625rem] font-bold tracking-wide uppercase ${meta?.badgeClass ?? 'bg-brand-mist text-teal-deep'}`}>
                 {meta?.label ?? post.channel}
             </span>
-            <h3 className="mt-2 text-lg leading-snug font-bold text-body">
+            <h3 className={`mt-2 leading-snug font-bold text-body ${isLead ? 'text-xl' : 'text-lg'}`}>
                 <Link href={`/articles/${post.slug}`} className="group-hover:text-teal-deep hover:underline">
                     {post.title}
                 </Link>
             </h3>
-            {post.excerpt && <p className="mt-3 text-sm leading-6 text-muted">{post.excerpt}</p>}
+            {post.excerpt && (
+                <p className={`mt-3 leading-6 text-muted ${isLead ? 'text-base' : 'text-sm'}`}>{post.excerpt}</p>
+            )}
             {published && (
                 <time dateTime={post.published_at ?? undefined} className="mt-3 block text-xs font-semibold text-muted">
                     {published}

--- a/resources/js/Components/Layout/AccountLayout.tsx
+++ b/resources/js/Components/Layout/AccountLayout.tsx
@@ -1,0 +1,36 @@
+import { type ReactNode } from 'react';
+import { Link } from '@inertiajs/react';
+import PublicLayout from './PublicLayout';
+
+type AccountLayoutProps = {
+    title: string;
+    description?: string;
+    backHref?: string;
+    backLabel?: string;
+    children: ReactNode;
+};
+
+export default function AccountLayout({
+    title,
+    description,
+    backHref,
+    backLabel = '← Back',
+    children,
+}: AccountLayoutProps) {
+    return (
+        <PublicLayout>
+            <main id="main-content" className="mx-auto max-w-lg px-5 py-12 sm:px-6">
+                {backHref && (
+                    <Link href={backHref} className="text-sm font-semibold text-teal-deep hover:underline">
+                        {backLabel}
+                    </Link>
+                )}
+                <div className={`form-panel ${backHref ? 'mt-6' : ''}`}>
+                    <h1 className="text-2xl font-bold text-body">{title}</h1>
+                    {description && <p className="mt-2 text-sm text-muted">{description}</p>}
+                    {children}
+                </div>
+            </main>
+        </PublicLayout>
+    );
+}

--- a/resources/js/Components/Layout/PublicLayout.tsx
+++ b/resources/js/Components/Layout/PublicLayout.tsx
@@ -66,7 +66,7 @@ export default function PublicLayout({ children }: { children: ReactNode }) {
             <a href="#main-content" className="skip-link">
                 Skip to main content
             </a>
-            <header className="sticky top-0 z-40 bg-brand-ink text-white">
+            <header className="sticky top-0 z-40 border-b-2 border-brand-teal/30 bg-brand-ink text-white">
                 <div className="mx-auto flex h-16 max-w-public items-center justify-between gap-6 px-5 sm:px-6">
                     <Link href="/" className="inline-flex shrink-0 rounded-control py-1">
                         <ApesLogo variant="masthead" className="h-12 w-auto object-contain" />

--- a/resources/js/Components/Layout/WorkspaceLayout.tsx
+++ b/resources/js/Components/Layout/WorkspaceLayout.tsx
@@ -32,8 +32,10 @@ function WorkspaceNavigation({ area, active }: { area: WorkspaceArea; active: 'm
                     key={link.href}
                     href={link.href}
                     aria-current={link.active ? 'page' : undefined}
-                    className={`flex min-h-11 items-center gap-3 rounded-control px-3 py-2 text-sm font-semibold transition-colors ${
-                        link.active ? 'bg-brand-teal text-brand-ink' : 'text-white hover:bg-white/10'
+                    className={`flex min-h-11 items-center gap-3 rounded-control border-l-4 px-3 py-2 text-sm font-semibold transition-colors ${
+                        link.active
+                            ? 'border-brand-teal bg-brand-teal text-brand-ink'
+                            : 'border-transparent text-white hover:bg-white/10'
                     }`}
                 >
                     <LineIcon name={link.icon} className="h-5 w-5 shrink-0" />

--- a/resources/js/Pages/Account/Profile.tsx
+++ b/resources/js/Pages/Account/Profile.tsx
@@ -1,5 +1,6 @@
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import PublicLayout from '../../Components/Layout/PublicLayout';
 
 type ProfileUser = {
     name: string;
@@ -34,77 +35,78 @@ export default function Profile({ user, status, can_delete_account, deletion_blo
     const deleteError = (errors as Record<string, string>).delete_account;
 
     return (
-        <>
+        <PublicLayout>
             <Head title="Your account" />
-            <main className="mx-auto flex min-h-screen max-w-lg flex-col gap-8 px-6 py-12">
-                <div>
-                    <h1 className="text-2xl font-semibold text-neutral-900">Your account</h1>
-                    <p className="mt-1 text-sm text-neutral-600">Manage your profile and data.</p>
+            <main id="main-content" className="mx-auto max-w-lg px-5 py-12 sm:px-6">
+                <div className="form-panel">
+                    <h1 className="text-2xl font-bold text-body">Your account</h1>
+                    <p className="mt-1 text-sm text-muted">Manage your profile and data.</p>
+
+                    {status === 'profile-updated' && <p className="status-badge-success mt-4">Profile updated.</p>}
+                    {status === 'email-verified' && <p className="status-badge-success mt-4">Email verified.</p>}
+
+                    <form onSubmit={submit} className="mt-6 flex flex-col gap-4">
+                        <div>
+                            <label htmlFor="name" className="text-sm font-bold text-body">Name</label>
+                            <input id="name" value={data.name} onChange={(e) => setData('name', e.target.value)} required className="form-input mt-1" />
+                            {errors.name && <p className="text-sm text-danger">{errors.name}</p>}
+                        </div>
+                        <div>
+                            <label htmlFor="email" className="text-sm font-bold text-body">Email</label>
+                            <input
+                                id="email"
+                                type="email"
+                                value={data.email}
+                                onChange={(e) => setData('email', e.target.value)}
+                                required
+                                disabled={user.auth_provider === 'cloudron_oidc'}
+                                className="form-input mt-1"
+                            />
+                            {errors.email && <p className="text-sm text-danger">{errors.email}</p>}
+                        </div>
+                        <button type="submit" disabled={processing} className="button-primary w-fit">
+                            Save changes
+                        </button>
+                    </form>
                 </div>
 
-                {status === 'profile-updated' && <p className="text-sm text-green-700">Profile updated.</p>}
-                {status === 'email-verified' && <p className="text-sm text-green-700">Email verified.</p>}
-
-                <form onSubmit={submit} className="flex flex-col gap-4">
-                    <div>
-                        <label htmlFor="name">Name</label>
-                        <input id="name" value={data.name} onChange={(e) => setData('name', e.target.value)} required />
-                        {errors.name && <p className="text-sm text-red-600">{errors.name}</p>}
-                    </div>
-                    <div>
-                        <label htmlFor="email">Email</label>
-                        <input
-                            id="email"
-                            type="email"
-                            value={data.email}
-                            onChange={(e) => setData('email', e.target.value)}
-                            required
-                            disabled={user.auth_provider === 'cloudron_oidc'}
-                        />
-                        {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
-                    </div>
-                    <button type="submit" disabled={processing}>
-                        Save changes
-                    </button>
-                </form>
-
-                <section className="flex flex-col gap-3 border-t border-neutral-200 pt-6">
-                    <h2 className="text-lg font-medium">Public profile</h2>
-                    <Link href="/account/public-profile" className="text-sm underline">
+                <div className="form-panel mt-6">
+                    <h2 className="text-lg font-bold text-body">Public profile</h2>
+                    <Link href="/account/public-profile" className="mt-2 inline-block text-sm text-teal-deep hover:underline">
                         Edit public profile
                     </Link>
-                </section>
+                </div>
 
-                <section className="flex flex-col gap-3 border-t border-neutral-200 pt-6">
-                    <h2 className="text-lg font-medium">Mailing lists</h2>
-                    <Link href="/account/mailing" className="text-sm underline">
+                <div className="form-panel mt-6">
+                    <h2 className="text-lg font-bold text-body">Mailing lists</h2>
+                    <Link href="/account/mailing" className="mt-2 inline-block text-sm text-teal-deep hover:underline">
                         Manage mailing preferences
                     </Link>
-                </section>
+                </div>
 
-                <section className="flex flex-col gap-3 border-t border-neutral-200 pt-6">
-                    <h2 className="text-lg font-medium">Your data</h2>
-                    <Link href="/account/export" className="text-sm underline">
+                <div className="form-panel mt-6">
+                    <h2 className="text-lg font-bold text-body">Your data</h2>
+                    <Link href="/account/export" className="mt-2 inline-block text-sm text-teal-deep hover:underline">
                         Download account data (JSON)
                     </Link>
-                </section>
+                </div>
 
-                <section className="flex flex-col gap-3 border-t border-neutral-200 pt-6">
-                    <h2 className="text-lg font-medium text-red-800">Danger zone</h2>
+                <div className="form-panel mt-6">
+                    <h2 className="text-lg font-bold text-danger">Danger zone</h2>
                     {can_delete_account ? (
-                        <button type="button" onClick={deleteAccount} className="w-fit text-sm text-red-700 underline">
+                        <button type="button" onClick={deleteAccount} className="button-danger mt-2">
                             Delete account
                         </button>
                     ) : (
-                        <p className="text-sm text-neutral-700">{deletion_block_reason}</p>
+                        <p className="mt-2 text-sm text-muted">{deletion_block_reason}</p>
                     )}
-                    {deleteError && <p className="text-sm text-red-600">{deleteError}</p>}
-                </section>
+                    {deleteError && <p className="text-sm text-danger">{deleteError}</p>}
+                </div>
 
-                <p className="text-sm">
-                    <Link href="/">Back to home</Link>
+                <p className="mt-6 text-sm">
+                    <Link href="/" className="text-teal-deep hover:underline">Back to home</Link>
                 </p>
             </main>
-        </>
+        </PublicLayout>
     );
 }

--- a/resources/js/Pages/Account/PublicProfile.tsx
+++ b/resources/js/Pages/Account/PublicProfile.tsx
@@ -1,5 +1,6 @@
-import { Head, Link, useForm } from '@inertiajs/react';
+import { Head, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import AccountLayout from '../../Components/Layout/AccountLayout';
 
 type ProfileData = {
     display_name: string | null;
@@ -26,58 +27,56 @@ export default function PublicProfile({ profile, status }: { profile: ProfileDat
     return (
         <>
             <Head title="Public profile" />
-            <main className="mx-auto max-w-lg px-6 py-12">
-                <Link href="/account" className="text-sm underline">
-                    ← Account
-                </Link>
-                <h1 className="mt-4 text-2xl font-semibold">Public profile</h1>
-                <p className="mt-2 text-sm text-neutral-600">
-                    Profiles are private by default. Opting in submits your profile for moderation before it appears
-                    publicly.
-                </p>
-                <p className="mt-2 text-sm">
+            <AccountLayout
+                title="Public profile"
+                description="Profiles are private by default. Opting in submits your profile for moderation before it appears publicly."
+                backHref="/account"
+                backLabel="← Account"
+            >
+                <p className="mt-4 text-sm text-body">
                     Status: <strong>{profile.moderation_status}</strong>
                 </p>
                 {profile.moderation_notes && (
-                    <p className="mt-1 text-sm text-red-700">Moderator note: {profile.moderation_notes}</p>
+                    <p className="status-badge-danger mt-2">Moderator note: {profile.moderation_notes}</p>
                 )}
                 {status === 'profile-submitted' && (
-                    <p className="mt-2 text-sm text-green-700">Profile saved. Public changes await moderation.</p>
+                    <p className="status-badge-success mt-2">Profile saved. Public changes await moderation.</p>
                 )}
 
-                <form onSubmit={submit} className="mt-8 flex flex-col gap-4">
+                <form onSubmit={submit} className="mt-6 flex flex-col gap-4">
                     <div>
-                        <label htmlFor="display_name">Display name</label>
+                        <label htmlFor="display_name" className="text-sm font-bold text-body">Display name</label>
                         <input
                             id="display_name"
                             value={data.display_name}
                             onChange={(e) => setData('display_name', e.target.value)}
-                            className="w-full rounded border px-3 py-2"
+                            className="form-input mt-1"
                         />
-                        {errors.display_name && <p className="text-sm text-red-600">{errors.display_name}</p>}
+                        {errors.display_name && <p className="text-sm text-danger">{errors.display_name}</p>}
                     </div>
                     <div>
-                        <label htmlFor="bio">Bio</label>
+                        <label htmlFor="bio" className="text-sm font-bold text-body">Bio</label>
                         <textarea
                             id="bio"
                             value={data.bio}
                             onChange={(e) => setData('bio', e.target.value)}
                             rows={4}
                             maxLength={500}
-                            className="w-full rounded border px-3 py-2"
+                            className="form-input mt-1"
                         />
                     </div>
                     <div>
-                        <label htmlFor="avatar">Avatar</label>
+                        <label htmlFor="avatar" className="text-sm font-bold text-body">Avatar</label>
                         <input
                             id="avatar"
                             type="file"
                             accept="image/jpeg,image/png,image/webp"
                             onChange={(e) => setData('avatar', e.target.files?.[0] ?? null)}
+                            className="mt-1 block text-sm"
                         />
-                        {errors.avatar && <p className="text-sm text-red-600">{errors.avatar}</p>}
+                        {errors.avatar && <p className="text-sm text-danger">{errors.avatar}</p>}
                     </div>
-                    <label className="flex gap-2 text-sm">
+                    <label className="flex gap-2 text-sm text-body">
                         <input
                             type="checkbox"
                             checked={data.public_opt_in}
@@ -85,11 +84,11 @@ export default function PublicProfile({ profile, status }: { profile: ProfileDat
                         />
                         Make my profile public after approval
                     </label>
-                    <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
+                    <button type="submit" disabled={processing} className="button-primary w-fit">
                         Save profile
                     </button>
                 </form>
-            </main>
+            </AccountLayout>
         </>
     );
 }

--- a/resources/js/Pages/Admin/Imports/GhostMembers.tsx
+++ b/resources/js/Pages/Admin/Imports/GhostMembers.tsx
@@ -30,7 +30,7 @@ export default function GhostMembersImport({ runs }: { runs: Run[] }) {
             <Head title="Ghost members import" />
             <main className="mx-auto max-w-3xl px-6 py-12">
                 <h1 className="text-2xl font-semibold">Ghost members CSV import</h1>
-                <p className="mt-2 text-sm text-neutral-600">
+                <p className="mt-2 text-sm text-muted">
                     Upload a Ghost Admin members export. Imports create mailing contacts only (not accounts). All-three-list
                     activation is fail-closed without historic evidence labels. No email is sent from import runs.
                 </p>
@@ -88,9 +88,9 @@ export default function GhostMembersImport({ runs }: { runs: Run[] }) {
                                 <p>
                                     #{run.id} — {run.status} — {run.dry_run ? 'dry-run' : 'import'}
                                 </p>
-                                <p className="text-neutral-600">Checksum: {run.source_checksum}</p>
+                                <p className="text-muted">Checksum: {run.source_checksum}</p>
                                 {run.report && (
-                                    <pre className="mt-2 overflow-auto rounded bg-neutral-100 p-2 text-xs">
+                                    <pre className="mt-2 overflow-auto rounded-control bg-page-tint p-2 text-xs">
                                         {JSON.stringify(run.report, null, 2)}
                                     </pre>
                                 )}
@@ -103,7 +103,7 @@ export default function GhostMembersImport({ runs }: { runs: Run[] }) {
                                 </button>
                             </li>
                         ))}
-                        {runs.length === 0 && <li className="text-neutral-600">No import runs yet.</li>}
+                        {runs.length === 0 && <li className="text-muted">No import runs yet.</li>}
                     </ul>
                 </section>
             </main>

--- a/resources/js/Pages/Archives/Author.tsx
+++ b/resources/js/Pages/Archives/Author.tsx
@@ -28,19 +28,19 @@ function ArchiveShell({
     return (
         <PublicLayout>
             <Head title={title} />
-            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
-                <h1 className="text-3xl font-semibold">{heading}</h1>
+            <main id="main-content" className="mx-auto max-w-public px-5 py-12 sm:px-6">
+                <h1 className="text-2xl font-bold text-body">{heading}</h1>
                 {posts.data.length === 0 ? (
-                    <p className="mt-6 text-neutral-600">No published stories in this archive.</p>
+                    <p className="mt-6 text-muted">No published stories in this archive.</p>
                 ) : (
                     <ul className="mt-6 space-y-4">
                         {posts.data.map((post) => (
-                            <li key={post.slug} className="border-b border-neutral-200 pb-4">
-                                <p className="text-sm text-apes-primary">{post.channel}</p>
-                                <Link href={`/articles/${post.slug}`} className="text-lg font-semibold hover:underline">
+                            <li key={post.slug} className="rounded-card border border-border bg-white p-4">
+                                <p className="text-xs font-bold tracking-wide text-apes-primary uppercase">{post.channel}</p>
+                                <Link href={`/articles/${post.slug}`} className="text-lg font-bold text-body hover:text-teal-deep hover:underline">
                                     {post.title}
                                 </Link>
-                                {post.excerpt && <p className="mt-1 text-sm text-neutral-600">{post.excerpt}</p>}
+                                {post.excerpt && <p className="mt-1 text-sm text-muted">{post.excerpt}</p>}
                             </li>
                         ))}
                     </ul>

--- a/resources/js/Pages/Archives/Date.tsx
+++ b/resources/js/Pages/Archives/Date.tsx
@@ -27,16 +27,16 @@ export default function DateArchive({
     return (
         <PublicLayout>
             <Head title={`Archive ${label}`} />
-            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
-                <h1 className="text-3xl font-semibold">Archive: {label}</h1>
+            <main id="main-content" className="mx-auto max-w-public px-5 py-12 sm:px-6">
+                <h1 className="text-2xl font-bold text-body">Archive: {label}</h1>
                 {posts.data.length === 0 ? (
-                    <p className="mt-6 text-neutral-600">No published stories in this period.</p>
+                    <p className="mt-6 text-muted">No published stories in this period.</p>
                 ) : (
                     <ul className="mt-6 space-y-4">
                         {posts.data.map((post) => (
-                            <li key={post.slug} className="border-b border-neutral-200 pb-4">
-                                <p className="text-sm text-apes-primary">{post.channel}</p>
-                                <Link href={`/articles/${post.slug}`} className="text-lg font-semibold hover:underline">
+                            <li key={post.slug} className="rounded-card border border-border bg-white p-4">
+                                <p className="text-xs font-bold tracking-wide text-apes-primary uppercase">{post.channel}</p>
+                                <Link href={`/articles/${post.slug}`} className="text-lg font-bold text-body hover:text-teal-deep hover:underline">
                                     {post.title}
                                 </Link>
                             </li>

--- a/resources/js/Pages/Archives/Tag.tsx
+++ b/resources/js/Pages/Archives/Tag.tsx
@@ -17,16 +17,16 @@ export default function TagArchive({ tag, posts }: { tag: { name: string; slug: 
     return (
         <PublicLayout>
             <Head title={`Tag: ${tag.name}`} />
-            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
-                <h1 className="text-3xl font-semibold">Tag: {tag.name}</h1>
+            <main id="main-content" className="mx-auto max-w-public px-5 py-12 sm:px-6">
+                <h1 className="text-2xl font-bold text-body">Tag: {tag.name}</h1>
                 {posts.data.length === 0 ? (
-                    <p className="mt-6 text-neutral-600">No published stories with this tag.</p>
+                    <p className="mt-6 text-muted">No published stories with this tag.</p>
                 ) : (
                     <ul className="mt-6 space-y-4">
                         {posts.data.map((post) => (
-                            <li key={post.slug} className="border-b border-neutral-200 pb-4">
-                                <p className="text-sm text-apes-primary">{post.channel}</p>
-                                <Link href={`/articles/${post.slug}`} className="text-lg font-semibold hover:underline">
+                            <li key={post.slug} className="rounded-card border border-border bg-white p-4">
+                                <p className="text-xs font-bold tracking-wide text-apes-primary uppercase">{post.channel}</p>
+                                <Link href={`/articles/${post.slug}`} className="text-lg font-bold text-body hover:text-teal-deep hover:underline">
                                     {post.title}
                                 </Link>
                             </li>

--- a/resources/js/Pages/Articles/Show.tsx
+++ b/resources/js/Pages/Articles/Show.tsx
@@ -1,5 +1,6 @@
 import { Head, Link, router, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import { channelMeta } from '../../channelMeta';
 import PublicLayout from '../../Components/Layout/PublicLayout';
 
 type Comment = {
@@ -87,15 +88,15 @@ export default function ArticleShow({
                 <div className="bg-amber-100 px-4 py-2 text-center text-sm text-amber-900">Preview — not indexed</div>
             )}
             <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
-                <Link href={`/${article.channel_slug}`} className="text-sm text-apes-primary">
+                <span className={`inline-flex rounded-control px-2 py-1 text-[0.625rem] font-bold tracking-wide uppercase ${channelMeta(article.channel_slug)?.badgeClass ?? 'bg-brand-mist text-teal-deep'}`}>
                     {article.channel}
-                </Link>
+                </span>
                 <article>
-                    <h1 className="mt-4 text-4xl font-semibold text-neutral-900">{article.title}</h1>
-                    <p className="mt-2 text-sm text-neutral-600">
+                    <h1 className="display-headline mt-4">{article.title}</h1>
+                    <p className="mt-2 text-sm text-muted">
                         By{' '}
                         {article.author_id ? (
-                            <Link href={`/authors/${article.author_id}`} className="underline">
+                            <Link href={`/authors/${article.author_id}`} className="text-teal-deep hover:underline">
                                 {article.author}
                             </Link>
                         ) : (
@@ -107,7 +108,7 @@ export default function ArticleShow({
                                 ·{' '}
                                 <Link
                                     href={`/archive/${new Date(article.published_at).getUTCFullYear()}`}
-                                    className="underline"
+                                    className="text-teal-deep hover:underline"
                                 >
                                     {new Date(article.published_at).toLocaleDateString('en-GB')}
                                 </Link>
@@ -121,7 +122,7 @@ export default function ArticleShow({
                                 const slug = typeof tag === 'string' ? tag.toLowerCase().replace(/\s+/g, '-') : tag.slug;
                                 return (
                                     <li key={slug}>
-                                        <Link href={`/tags/${slug}`} className="rounded border px-2 py-0.5 underline">
+                                        <Link href={`/tags/${slug}`} className="rounded-control border border-border px-2 py-0.5 text-teal-deep hover:underline">
                                             {name}
                                         </Link>
                                     </li>
@@ -130,14 +131,14 @@ export default function ArticleShow({
                         </ul>
                     )}
                     <div
-                        className="prose prose-neutral mt-8 max-w-none"
+                        className="prose mt-8 max-w-none"
                         dangerouslySetInnerHTML={{ __html: article.html }}
                     />
                 </article>
 
                 {!preview && (
-                    <section className="mt-12 border-t border-neutral-200 pt-8" aria-label="Reactions">
-                        <h2 className="text-lg font-medium">Reactions</h2>
+                    <section className="mt-12 border-t border-border pt-8" aria-label="Reactions">
+                        <h2 className="text-lg font-bold text-body">Reactions</h2>
                         <div className="mt-3 flex flex-wrap gap-3">
                             {Object.entries(reactionLabels).map(([type, label]) => {
                                 const active = reactions.mine.includes(type);
@@ -149,7 +150,7 @@ export default function ArticleShow({
                                         disabled={!canEngage}
                                         onClick={() => toggleReaction(type)}
                                         aria-pressed={active}
-                                        className={`rounded border px-3 py-1.5 text-sm ${active ? 'border-apes-primary bg-apes-primary/10' : 'border-neutral-300'}`}
+                                        className={`min-h-11 rounded-control border px-3 py-1.5 text-sm ${active ? 'border-apes-primary bg-apes-mist text-apes-primary' : 'border-border text-body'}`}
                                     >
                                         {label} <span className="tabular-nums">({count})</span>
                                     </button>
@@ -157,8 +158,8 @@ export default function ArticleShow({
                             })}
                         </div>
                         {!canEngage && (
-                            <p className="mt-2 text-sm text-neutral-600">
-                                <Link href="/login" className="underline">
+                            <p className="mt-2 text-sm text-muted">
+                                <Link href="/login" className="text-teal-deep hover:underline">
                                     Sign in
                                 </Link>{' '}
                                 with a verified account to react.
@@ -168,21 +169,21 @@ export default function ArticleShow({
                 )}
 
                 {!preview && (
-                    <section className="mt-10 border-t border-neutral-200 pt-8" aria-label="Comments">
-                        <h2 className="text-lg font-medium">Comments</h2>
+                    <section className="mt-10 border-t border-border pt-8" aria-label="Comments">
+                        <h2 className="text-lg font-bold text-body">Comments</h2>
                         {status === 'comment-pending' && (
-                            <p className="mt-2 text-sm text-green-700">Thanks — your comment is awaiting moderation.</p>
+                            <p className="status-badge-success mt-2">Thanks — your comment is awaiting moderation.</p>
                         )}
 
                         <ul className="mt-4 flex flex-col gap-4">
                             {comments.map((comment) => (
-                                <li key={comment.id} className="border-b border-neutral-100 pb-4">
-                                    <p className="text-sm font-medium">{comment.author.display_name}</p>
-                                    <p className="mt-1 text-neutral-800">{comment.body}</p>
+                                <li key={comment.id} className="border-b border-border pb-4">
+                                    <p className="text-sm font-bold text-body">{comment.author.display_name}</p>
+                                    <p className="mt-1 text-body">{comment.body}</p>
                                     {canEngage && (
                                         <button
                                             type="button"
-                                            className="mt-2 text-xs text-neutral-600 underline"
+                                            className="mt-2 text-xs text-muted hover:underline"
                                             onClick={() => {
                                                 const reason = window.prompt('Why are you reporting this comment?');
                                                 if (!reason) {
@@ -200,12 +201,12 @@ export default function ArticleShow({
                                     )}
                                 </li>
                             ))}
-                            {comments.length === 0 && <li className="text-sm text-neutral-600">No approved comments yet.</li>}
+                            {comments.length === 0 && <li className="text-sm text-muted">No approved comments yet.</li>}
                         </ul>
 
                         {canEngage ? (
                             <form onSubmit={submitComment} className="mt-6 flex flex-col gap-3">
-                                <label htmlFor="comment-body" className="text-sm font-medium">
+                                <label htmlFor="comment-body" className="text-sm font-bold text-body">
                                     Add a comment
                                 </label>
                                 <textarea
@@ -215,22 +216,22 @@ export default function ArticleShow({
                                     rows={3}
                                     required
                                     maxLength={2000}
-                                    className="w-full rounded border px-3 py-2"
+                                    className="form-input"
                                 />
                                 {commentForm.errors.body && (
-                                    <p className="text-sm text-red-600">{commentForm.errors.body}</p>
+                                    <p className="text-sm text-danger">{commentForm.errors.body}</p>
                                 )}
                                 <button
                                     type="submit"
                                     disabled={commentForm.processing}
-                                    className="w-fit rounded bg-apes-primary px-4 py-2 text-white"
+                                    className="button-primary w-fit"
                                 >
                                     Submit for moderation
                                 </button>
                             </form>
                         ) : (
-                            <p className="mt-4 text-sm text-neutral-600">
-                                <Link href="/login" className="underline">
+                            <p className="mt-4 text-sm text-muted">
+                                <Link href="/login" className="text-teal-deep hover:underline">
                                     Sign in
                                 </Link>{' '}
                                 with a verified account to comment.

--- a/resources/js/Pages/Auth/ForgotPassword.tsx
+++ b/resources/js/Pages/Auth/ForgotPassword.tsx
@@ -1,5 +1,6 @@
 import { Head, useForm, usePage } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import AuthCard from '../../Components/Auth/AuthCard';
 
 export default function ForgotPassword() {
     const { data, setData, post, processing, errors } = useForm({
@@ -15,20 +16,19 @@ export default function ForgotPassword() {
     return (
         <>
             <Head title="Forgot password" />
-            <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6">
-                <h1 className="text-2xl font-semibold text-neutral-900">Forgot your password?</h1>
-                {status && <p className="text-sm text-green-700">{status}</p>}
+            <AuthCard title="Forgot your password?">
+                {status && <p className="status-badge-success mb-4">{status}</p>}
                 <form onSubmit={submit} className="flex flex-col gap-4">
                     <div>
-                        <label htmlFor="email">Email</label>
-                        <input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required autoFocus />
-                        {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
+                        <label htmlFor="email" className="text-sm font-bold text-body">Email</label>
+                        <input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required autoFocus className="form-input mt-1" />
+                        {errors.email && <p className="text-sm text-danger">{errors.email}</p>}
                     </div>
-                    <button type="submit" disabled={processing}>
+                    <button type="submit" disabled={processing} className="button-primary">
                         Email password reset link
                     </button>
                 </form>
-            </main>
+            </AuthCard>
         </>
     );
 }

--- a/resources/js/Pages/Auth/Login.tsx
+++ b/resources/js/Pages/Auth/Login.tsx
@@ -1,5 +1,6 @@
 import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import AuthCard from '../../Components/Auth/AuthCard';
 
 interface LoginProps {
     staffLoginUrl: string | null;
@@ -31,29 +32,25 @@ export default function Login({ staffLoginUrl, staffLoginLabel }: LoginProps) {
     return (
         <>
             <Head title="Log in" />
-            <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6">
-                <h1 className="text-2xl font-semibold text-neutral-900">Log in</h1>
+            <AuthCard title="Log in">
                 {staffLoginUrl && (
-                    <div className="flex flex-col gap-2">
-                        <a
-                            href={staffLoginUrl}
-                            className="rounded border border-neutral-300 px-4 py-2 text-center text-sm font-medium text-neutral-900 hover:bg-neutral-50"
-                        >
+                    <div className="mb-6 flex flex-col gap-2">
+                        <a href={staffLoginUrl} className="button-secondary w-full">
                             {staffLoginLabel ?? 'Staff sign in'}
                         </a>
-                        <p className="text-center text-xs text-neutral-500">or use a public account below</p>
+                        <p className="text-center text-xs text-muted">or use a public account below</p>
                     </div>
                 )}
                 {devTools && (
-                    <div className="flex flex-col gap-2 rounded border border-amber-300 bg-amber-50 p-3">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-amber-800">Local role preview</p>
+                    <div className="mb-6 flex flex-col gap-2 rounded-control border border-warning bg-warning-mist p-3">
+                        <p className="text-xs font-bold tracking-wide text-warning uppercase">Local role preview</p>
                         <div className="flex flex-wrap gap-1.5">
                             {DEV_ROLES.map((role) => (
                                 <button
                                     key={role.key}
                                     type="button"
                                     onClick={() => router.post(`/_dev/login/${role.key}`)}
-                                    className="rounded border border-amber-700/30 bg-white px-2.5 py-1 text-xs font-medium text-amber-950 hover:bg-amber-100"
+                                    className="button-secondary px-2.5 py-1 text-xs"
                                 >
                                     {role.label}
                                 </button>
@@ -63,33 +60,34 @@ export default function Login({ staffLoginUrl, staffLoginLabel }: LoginProps) {
                 )}
                 <form onSubmit={submit} className="flex flex-col gap-4">
                     <div>
-                        <label htmlFor="email">Email</label>
-                        <input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required autoFocus />
-                        {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
+                        <label htmlFor="email" className="text-sm font-bold text-body">Email</label>
+                        <input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required autoFocus className="form-input mt-1" />
+                        {errors.email && <p className="text-sm text-danger">{errors.email}</p>}
                     </div>
                     <div>
-                        <label htmlFor="password">Password</label>
+                        <label htmlFor="password" className="text-sm font-bold text-body">Password</label>
                         <input
                             id="password"
                             type="password"
                             value={data.password}
                             onChange={(e) => setData('password', e.target.value)}
                             required
+                            className="form-input mt-1"
                         />
-                        {errors.password && <p className="text-sm text-red-600">{errors.password}</p>}
+                        {errors.password && <p className="text-sm text-danger">{errors.password}</p>}
                     </div>
-                    <button type="submit" disabled={processing}>
+                    <button type="submit" disabled={processing} className="button-primary">
                         Log in
                     </button>
                 </form>
-                <p className="flex flex-col gap-1 text-sm">
-                    <Link href="/login/magic-link">Email me a sign-in link instead</Link>
-                    <Link href="/forgot-password">Forgot your password?</Link>
+                <p className="mt-6 flex flex-col gap-1 text-sm text-muted">
+                    <Link href="/login/magic-link" className="text-teal-deep hover:underline">Email me a sign-in link instead</Link>
+                    <Link href="/forgot-password" className="text-teal-deep hover:underline">Forgot your password?</Link>
                     <span>
-                        Need an account? <Link href="/register">Register</Link>
+                        Need an account? <Link href="/register" className="text-teal-deep hover:underline">Register</Link>
                     </span>
                 </p>
-            </main>
+            </AuthCard>
         </>
     );
 }

--- a/resources/js/Pages/Auth/MagicLinkRequest.tsx
+++ b/resources/js/Pages/Auth/MagicLinkRequest.tsx
@@ -1,5 +1,6 @@
 import { Head, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import AuthCard from '../../Components/Auth/AuthCard';
 
 export default function MagicLinkRequest() {
     const { data, setData, post, processing, errors } = useForm({
@@ -14,19 +15,18 @@ export default function MagicLinkRequest() {
     return (
         <>
             <Head title="Email me a sign-in link" />
-            <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6">
-                <h1 className="text-2xl font-semibold text-neutral-900">Email me a sign-in link</h1>
+            <AuthCard title="Email me a sign-in link">
                 <form onSubmit={submit} className="flex flex-col gap-4">
                     <div>
-                        <label htmlFor="email">Email</label>
-                        <input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required autoFocus />
-                        {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
+                        <label htmlFor="email" className="text-sm font-bold text-body">Email</label>
+                        <input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required autoFocus className="form-input mt-1" />
+                        {errors.email && <p className="text-sm text-danger">{errors.email}</p>}
                     </div>
-                    <button type="submit" disabled={processing}>
+                    <button type="submit" disabled={processing} className="button-primary">
                         Send link
                     </button>
                 </form>
-            </main>
+            </AuthCard>
         </>
     );
 }

--- a/resources/js/Pages/Auth/MagicLinkSent.tsx
+++ b/resources/js/Pages/Auth/MagicLinkSent.tsx
@@ -1,16 +1,16 @@
 import { Head } from '@inertiajs/react';
+import AuthCard from '../../Components/Auth/AuthCard';
 
 export default function MagicLinkSent() {
     return (
         <>
             <Head title="Check your email" />
-            <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-4 px-6">
-                <h1 className="text-2xl font-semibold text-neutral-900">Check your email</h1>
-                <p className="text-neutral-600">
+            <AuthCard title="Check your email">
+                <p className="text-muted">
                     If an account exists for that address, we&apos;ve sent a sign-in link. It expires in 15 minutes and can only be used
                     once.
                 </p>
-            </main>
+            </AuthCard>
         </>
     );
 }

--- a/resources/js/Pages/Auth/Register.tsx
+++ b/resources/js/Pages/Auth/Register.tsx
@@ -1,5 +1,6 @@
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import AuthCard from '../../Components/Auth/AuthCard';
 
 export default function Register() {
     const { data, setData, post, processing, errors, reset } = useForm({
@@ -19,48 +20,35 @@ export default function Register() {
     return (
         <>
             <Head title="Register" />
-            <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6">
-                <h1 className="text-2xl font-semibold text-neutral-900">Create an account</h1>
+            <AuthCard title="Create an account">
                 <form onSubmit={submit} className="flex flex-col gap-4">
                     <div>
-                        <label htmlFor="name">Name</label>
-                        <input id="name" value={data.name} onChange={(e) => setData('name', e.target.value)} required autoFocus />
-                        {errors.name && <p className="text-sm text-red-600">{errors.name}</p>}
+                        <label htmlFor="name" className="text-sm font-bold text-body">Name</label>
+                        <input id="name" value={data.name} onChange={(e) => setData('name', e.target.value)} required autoFocus className="form-input mt-1" />
+                        {errors.name && <p className="text-sm text-danger">{errors.name}</p>}
                     </div>
                     <div>
-                        <label htmlFor="email">Email</label>
-                        <input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required />
-                        {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
+                        <label htmlFor="email" className="text-sm font-bold text-body">Email</label>
+                        <input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required className="form-input mt-1" />
+                        {errors.email && <p className="text-sm text-danger">{errors.email}</p>}
                     </div>
                     <div>
-                        <label htmlFor="password">Password</label>
-                        <input
-                            id="password"
-                            type="password"
-                            value={data.password}
-                            onChange={(e) => setData('password', e.target.value)}
-                            required
-                        />
-                        {errors.password && <p className="text-sm text-red-600">{errors.password}</p>}
+                        <label htmlFor="password" className="text-sm font-bold text-body">Password</label>
+                        <input id="password" type="password" value={data.password} onChange={(e) => setData('password', e.target.value)} required className="form-input mt-1" />
+                        {errors.password && <p className="text-sm text-danger">{errors.password}</p>}
                     </div>
                     <div>
-                        <label htmlFor="password_confirmation">Confirm password</label>
-                        <input
-                            id="password_confirmation"
-                            type="password"
-                            value={data.password_confirmation}
-                            onChange={(e) => setData('password_confirmation', e.target.value)}
-                            required
-                        />
+                        <label htmlFor="password_confirmation" className="text-sm font-bold text-body">Confirm password</label>
+                        <input id="password_confirmation" type="password" value={data.password_confirmation} onChange={(e) => setData('password_confirmation', e.target.value)} required className="form-input mt-1" />
                     </div>
-                    <button type="submit" disabled={processing}>
+                    <button type="submit" disabled={processing} className="button-primary">
                         Register
                     </button>
                 </form>
-                <p className="text-sm">
-                    Already have an account? <Link href="/login">Log in</Link>
+                <p className="mt-6 text-sm text-muted">
+                    Already have an account? <Link href="/login" className="text-teal-deep hover:underline">Log in</Link>
                 </p>
-            </main>
+            </AuthCard>
         </>
     );
 }

--- a/resources/js/Pages/Auth/ResetPassword.tsx
+++ b/resources/js/Pages/Auth/ResetPassword.tsx
@@ -1,5 +1,6 @@
 import { Head, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import AuthCard from '../../Components/Auth/AuthCard';
 
 interface Props {
     email: string;
@@ -24,41 +25,27 @@ export default function ResetPassword({ email, token }: Props) {
     return (
         <>
             <Head title="Reset password" />
-            <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6">
-                <h1 className="text-2xl font-semibold text-neutral-900">Reset your password</h1>
+            <AuthCard title="Reset your password">
                 <form onSubmit={submit} className="flex flex-col gap-4">
                     <div>
-                        <label htmlFor="email">Email</label>
-                        <input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required />
-                        {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
+                        <label htmlFor="email" className="text-sm font-bold text-body">Email</label>
+                        <input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required className="form-input mt-1" />
+                        {errors.email && <p className="text-sm text-danger">{errors.email}</p>}
                     </div>
                     <div>
-                        <label htmlFor="password">New password</label>
-                        <input
-                            id="password"
-                            type="password"
-                            value={data.password}
-                            onChange={(e) => setData('password', e.target.value)}
-                            required
-                            autoFocus
-                        />
-                        {errors.password && <p className="text-sm text-red-600">{errors.password}</p>}
+                        <label htmlFor="password" className="text-sm font-bold text-body">New password</label>
+                        <input id="password" type="password" value={data.password} onChange={(e) => setData('password', e.target.value)} required autoFocus className="form-input mt-1" />
+                        {errors.password && <p className="text-sm text-danger">{errors.password}</p>}
                     </div>
                     <div>
-                        <label htmlFor="password_confirmation">Confirm new password</label>
-                        <input
-                            id="password_confirmation"
-                            type="password"
-                            value={data.password_confirmation}
-                            onChange={(e) => setData('password_confirmation', e.target.value)}
-                            required
-                        />
+                        <label htmlFor="password_confirmation" className="text-sm font-bold text-body">Confirm new password</label>
+                        <input id="password_confirmation" type="password" value={data.password_confirmation} onChange={(e) => setData('password_confirmation', e.target.value)} required className="form-input mt-1" />
                     </div>
-                    <button type="submit" disabled={processing}>
+                    <button type="submit" disabled={processing} className="button-primary">
                         Reset password
                     </button>
                 </form>
-            </main>
+            </AuthCard>
         </>
     );
 }

--- a/resources/js/Pages/Auth/VerifyEmail.tsx
+++ b/resources/js/Pages/Auth/VerifyEmail.tsx
@@ -1,5 +1,6 @@
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import AuthCard from '../../Components/Auth/AuthCard';
 
 export default function VerifyEmail({ status }: { status?: string }) {
     const { post, processing } = useForm({});
@@ -12,25 +13,24 @@ export default function VerifyEmail({ status }: { status?: string }) {
     return (
         <>
             <Head title="Verify email" />
-            <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6">
-                <h1 className="text-2xl font-semibold text-neutral-900">Verify your email</h1>
-                <p className="text-sm text-neutral-600">
-                    Thanks for registering. Please check your email for a verification link before using your account.
-                </p>
+            <AuthCard
+                title="Verify your email"
+                description="Thanks for registering. Please check your email for a verification link before using your account."
+            >
                 {status === 'verification-link-sent' && (
-                    <p className="text-sm text-green-700">A new verification link has been sent to your email address.</p>
+                    <p className="status-badge-success mb-4">A new verification link has been sent to your email address.</p>
                 )}
                 <form onSubmit={submit}>
-                    <button type="submit" disabled={processing}>
+                    <button type="submit" disabled={processing} className="button-primary">
                         Resend verification email
                     </button>
                 </form>
-                <p className="text-sm">
-                    <Link href="/logout" method="post" as="button">
+                <p className="mt-6 text-sm">
+                    <Link href="/logout" method="post" as="button" className="text-teal-deep hover:underline">
                         Log out
                     </Link>
                 </p>
-            </main>
+            </AuthCard>
         </>
     );
 }

--- a/resources/js/Pages/Channels/Show.tsx
+++ b/resources/js/Pages/Channels/Show.tsx
@@ -1,4 +1,5 @@
 import { Head, Link } from '@inertiajs/react';
+import { channelMeta } from '../../channelMeta';
 import PublicLayout from '../../Components/Layout/PublicLayout';
 
 type Post = {
@@ -16,22 +17,43 @@ export default function ChannelShow({
     channel: { slug: string; label: string };
     posts: { data: Post[] };
 }) {
+    const meta = channelMeta(channel.slug);
+    const headerClass =
+        meta?.accent === 'apes' ? 'bg-apes-mist border-apes-primary' :
+        meta?.accent === 'shelter' ? 'bg-shelter-mist border-shelter-accent' :
+        meta?.accent === 'clinic' ? 'bg-clinic-mist border-clinic-accent' :
+        'bg-brand-mist border-brand-teal';
+
     return (
         <PublicLayout>
             <Head title={channel.label} />
-            <main id="main-content" className="mx-auto max-w-5xl px-6 py-12">
-                <h1 className="text-3xl font-semibold text-neutral-900">{channel.label}</h1>
-                <ul className="mt-8 grid gap-6">
-                    {posts.data.map((post) => (
-                        <li key={post.slug} className="border-b border-neutral-200 pb-6">
-                            <h2 className="text-xl font-semibold">
-                                <Link href={`/articles/${post.slug}`}>{post.title}</Link>
-                            </h2>
-                            {post.excerpt && <p className="mt-2 text-neutral-600">{post.excerpt}</p>}
-                            <p className="mt-2 text-sm text-neutral-500">{post.author}</p>
-                        </li>
-                    ))}
-                </ul>
+            <main id="main-content">
+                <div className={`editorial-rule border-b border-border ${headerClass} px-5 py-12 sm:px-6`}>
+                    <div className="mx-auto max-w-public">
+                        <p className="eyebrow">Channel</p>
+                        <h1 className="mt-2 text-2xl font-bold text-body sm:text-3xl">{channel.label}</h1>
+                        {meta?.description && <p className="mt-2 max-w-2xl text-muted">{meta.description}</p>}
+                    </div>
+                </div>
+                <div className="mx-auto max-w-public px-5 py-12 sm:px-6">
+                    {posts.data.length === 0 ? (
+                        <p className="text-muted">No published stories in this channel yet.</p>
+                    ) : (
+                        <ul className="grid gap-8 md:grid-cols-2">
+                            {posts.data.map((post) => (
+                                <li key={post.slug} className="rounded-card border border-border bg-white p-6">
+                                    <h2 className="text-lg font-bold text-body">
+                                        <Link href={`/articles/${post.slug}`} className="hover:text-teal-deep hover:underline">
+                                            {post.title}
+                                        </Link>
+                                    </h2>
+                                    {post.excerpt && <p className="mt-2 text-sm leading-6 text-muted">{post.excerpt}</p>}
+                                    <p className="mt-3 text-xs font-semibold text-muted">{post.author}</p>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
             </main>
         </PublicLayout>
     );

--- a/resources/js/Pages/Legal/Cookies.tsx
+++ b/resources/js/Pages/Legal/Cookies.tsx
@@ -5,7 +5,7 @@ export default function Cookies() {
     return (
         <PublicLayout>
             <Head title="Cookie notice" />
-            <main id="main-content" className="prose prose-neutral mx-auto max-w-3xl px-6 py-12">
+            <main id="main-content" className="prose mx-auto max-w-public px-5 py-12 sm:px-6">
                 <h1>Cookie notice</h1>
                 <p>
                     We use essential cookies and similar storage required to sign you in, protect forms (CSRF), and keep

--- a/resources/js/Pages/Legal/Privacy.tsx
+++ b/resources/js/Pages/Legal/Privacy.tsx
@@ -7,7 +7,7 @@ export default function Privacy() {
     return (
         <PublicLayout>
             <Head title="Privacy notice" />
-            <main id="main-content" className="prose prose-neutral mx-auto max-w-3xl px-6 py-12">
+            <main id="main-content" className="prose mx-auto max-w-public px-5 py-12 sm:px-6">
                 <h1>Privacy notice</h1>
                 <p>
                     APES Newsroom is operated by APES CIC. This draft notice explains how we process personal data for

--- a/resources/js/Pages/Legal/Rights.tsx
+++ b/resources/js/Pages/Legal/Rights.tsx
@@ -5,7 +5,7 @@ export default function Rights() {
     return (
         <PublicLayout>
             <Head title="Your data rights" />
-            <main id="main-content" className="prose prose-neutral mx-auto max-w-3xl px-6 py-12">
+            <main id="main-content" className="prose mx-auto max-w-public px-5 py-12 sm:px-6">
                 <h1>Your data rights</h1>
                 <ul>
                     <li>

--- a/resources/js/Pages/Mailing/Preferences.tsx
+++ b/resources/js/Pages/Mailing/Preferences.tsx
@@ -1,5 +1,6 @@
 import { Head, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import AccountLayout from '../../Components/Layout/AccountLayout';
 
 type ListState = { list: string; label: string; purpose: string; status: string | null };
 
@@ -35,17 +36,19 @@ export default function Preferences({
     return (
         <>
             <Head title="Mailing preferences" />
-            <main className="mx-auto max-w-lg px-6 py-12">
-                <h1 className="text-2xl font-semibold">Mailing preferences</h1>
-                <p className="mt-2 text-sm text-neutral-600">Manage lists for {email}. New lists need email confirmation.</p>
-
+            <AccountLayout
+                title="Mailing preferences"
+                description={`Manage lists for ${email}. New lists need email confirmation.`}
+                backHref={signed ? undefined : '/account'}
+                backLabel="← Account"
+            >
                 {status === 'preferences-updated' && (
-                    <p className="mt-4 text-sm text-green-700">Preferences saved. Confirm any new lists via email.</p>
+                    <p className="status-badge-success mt-4">Preferences saved. Confirm any new lists via email.</p>
                 )}
 
-                <form onSubmit={submit} className="mt-8 flex flex-col gap-4">
+                <form onSubmit={submit} className="mt-6 flex flex-col gap-4">
                     <fieldset className="flex flex-col gap-3">
-                        <legend className="font-medium">Lists</legend>
+                        <legend className="text-sm font-bold text-body">Lists</legend>
                         {lists.map((list) => (
                             <label key={list.list} className="flex gap-3 text-sm">
                                 <input
@@ -54,21 +57,21 @@ export default function Preferences({
                                     onChange={() => toggleList(list.list)}
                                 />
                                 <span>
-                                    <span className="font-medium">{list.label}</span>
+                                    <span className="font-bold text-body">{list.label}</span>
                                     {list.status && (
-                                        <span className="ml-2 text-xs text-neutral-500">({list.status})</span>
+                                        <span className="ml-2 text-xs text-muted">({list.status})</span>
                                     )}
-                                    <span className="block text-neutral-600">{list.purpose}</span>
+                                    <span className="block text-muted">{list.purpose}</span>
                                 </span>
                             </label>
                         ))}
-                        {errors.lists && <p className="text-sm text-red-600">{errors.lists}</p>}
+                        {errors.lists && <p className="text-sm text-danger">{errors.lists}</p>}
                     </fieldset>
-                    <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
+                    <button type="submit" disabled={processing} className="button-primary w-fit">
                         Save preferences
                     </button>
                 </form>
-            </main>
+            </AccountLayout>
         </>
     );
 }

--- a/resources/js/Pages/Mailing/Signup.tsx
+++ b/resources/js/Pages/Mailing/Signup.tsx
@@ -25,57 +25,55 @@ export default function Signup({ lists, status }: { lists: ListOption[]; status?
     return (
         <PublicLayout>
             <Head title="Mailing lists" />
-            <main id="main-content" className="mx-auto max-w-lg px-6 py-12">
-                <h1 className="text-2xl font-semibold">APES Newsroom mailing lists</h1>
-                <p className="mt-2 text-sm text-neutral-600">
-                    Choose which APES lists you want. Nothing is pre-selected. We will email you a confirmation link for
-                    each list before sending any news.
-                </p>
+            <main id="main-content" className="mx-auto max-w-lg px-5 py-12 sm:px-6">
+                <div className="form-panel">
+                    <h1 className="text-2xl font-bold text-body">APES Newsroom mailing lists</h1>
+                    <p className="mt-2 text-sm text-muted">
+                        Choose which APES lists you want. Nothing is pre-selected. We will email you a confirmation link for
+                        each list before sending any news.
+                    </p>
 
-                {status === 'check-email' && (
-                    <p className="mt-4 text-sm text-green-700">Check your email to confirm each list you selected.</p>
-                )}
+                    {status === 'check-email' && (
+                        <p className="status-badge-success mt-4">Check your email to confirm each list you selected.</p>
+                    )}
 
-                <form onSubmit={submit} className="mt-8 flex flex-col gap-4">
-                    <div>
-                        <label htmlFor="email">Email address</label>
-                        <input
-                            id="email"
-                            type="email"
-                            required
-                            value={data.email}
-                            onChange={(e) => setData('email', e.target.value)}
-                            className="w-full rounded border px-3 py-2"
-                        />
-                        {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
-                    </div>
+                    <form onSubmit={submit} className="mt-6 flex flex-col gap-4">
+                        <div>
+                            <label htmlFor="email" className="text-sm font-bold text-body">Email address</label>
+                            <input
+                                id="email"
+                                type="email"
+                                required
+                                value={data.email}
+                                onChange={(e) => setData('email', e.target.value)}
+                                className="form-input mt-1"
+                            />
+                            {errors.email && <p className="text-sm text-danger">{errors.email}</p>}
+                        </div>
 
-                    <fieldset className="flex flex-col gap-3">
-                        <legend className="font-medium">Lists</legend>
-                        {lists.map((list) => (
-                            <label key={list.value} className="flex gap-3 text-sm">
-                                <input
-                                    type="checkbox"
-                                    checked={data.lists.includes(list.value)}
-                                    onChange={() => toggleList(list.value)}
-                                />
-                                <span>
-                                    <span className="font-medium">{list.label}</span>
-                                    <span className="block text-neutral-600">{list.purpose}</span>
-                                </span>
-                            </label>
-                        ))}
-                        {errors.lists && <p className="text-sm text-red-600">{errors.lists}</p>}
-                    </fieldset>
+                        <fieldset className="flex flex-col gap-3">
+                            <legend className="text-sm font-bold text-body">Lists</legend>
+                            {lists.map((list) => (
+                                <label key={list.value} className="flex gap-3 text-sm">
+                                    <input
+                                        type="checkbox"
+                                        checked={data.lists.includes(list.value)}
+                                        onChange={() => toggleList(list.value)}
+                                    />
+                                    <span>
+                                        <span className="font-bold text-body">{list.label}</span>
+                                        <span className="block text-muted">{list.purpose}</span>
+                                    </span>
+                                </label>
+                            ))}
+                            {errors.lists && <p className="text-sm text-danger">{errors.lists}</p>}
+                        </fieldset>
 
-                    <button
-                        type="submit"
-                        disabled={processing}
-                        className="w-fit rounded bg-apes-primary px-4 py-2 text-white"
-                    >
-                        Subscribe
-                    </button>
-                </form>
+                        <button type="submit" disabled={processing} className="button-primary w-fit">
+                            Subscribe
+                        </button>
+                    </form>
+                </div>
             </main>
         </PublicLayout>
     );

--- a/resources/js/Pages/Mailing/Unsubscribe.tsx
+++ b/resources/js/Pages/Mailing/Unsubscribe.tsx
@@ -1,5 +1,6 @@
 import { Head, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import AccountLayout from '../../Components/Layout/AccountLayout';
 
 type ListOption = { value: string; label: string };
 
@@ -17,15 +18,15 @@ export default function Unsubscribe({ email, lists }: { email: string; lists: Li
     return (
         <>
             <Head title="Unsubscribe" />
-            <main className="mx-auto max-w-lg px-6 py-12">
-                <h1 className="text-2xl font-semibold">Unsubscribe</h1>
-                <p className="mt-2 text-sm text-neutral-600">Update mailing preferences for {email}. No login required.</p>
-
-                <form onSubmit={submit} className="mt-8 flex flex-col gap-4">
+            <AccountLayout
+                title="Unsubscribe"
+                description={`Update mailing preferences for ${email}. No login required.`}
+            >
+                <form onSubmit={submit} className="mt-6 flex flex-col gap-4">
                     <fieldset className="flex flex-col gap-3">
-                        <legend className="font-medium">Leave a specific list</legend>
+                        <legend className="text-sm font-bold text-body">Leave a specific list</legend>
                         {lists.map((list) => (
-                            <label key={list.value} className="flex gap-3 text-sm">
+                            <label key={list.value} className="flex gap-3 text-sm text-body">
                                 <input
                                     type="radio"
                                     name="list"
@@ -35,7 +36,7 @@ export default function Unsubscribe({ email, lists }: { email: string; lists: Li
                                 {list.label}
                             </label>
                         ))}
-                        <label className="flex gap-3 text-sm font-medium">
+                        <label className="flex gap-3 text-sm font-bold text-body">
                             <input
                                 type="radio"
                                 name="list"
@@ -45,11 +46,11 @@ export default function Unsubscribe({ email, lists }: { email: string; lists: Li
                             Unsubscribe from all lists
                         </label>
                     </fieldset>
-                    <button type="submit" disabled={processing} className="w-fit rounded bg-apes-primary px-4 py-2 text-white">
+                    <button type="submit" disabled={processing} className="button-primary w-fit">
                         Confirm
                     </button>
                 </form>
-            </main>
+            </AccountLayout>
         </>
     );
 }

--- a/resources/js/Pages/Search/Index.tsx
+++ b/resources/js/Pages/Search/Index.tsx
@@ -15,8 +15,8 @@ export default function SearchIndex({ query, results }: { query: string; results
     return (
         <PublicLayout>
             <Head title="Search" />
-            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
-                <h1 className="text-2xl font-semibold">Search</h1>
+            <main id="main-content" className="mx-auto max-w-public px-5 py-12 sm:px-6">
+                <h1 className="text-2xl font-bold text-body">Search</h1>
                 <form onSubmit={submit} className="mt-4 flex gap-2">
                     <label htmlFor="q" className="sr-only">
                         Search
@@ -25,20 +25,20 @@ export default function SearchIndex({ query, results }: { query: string; results
                         id="q"
                         value={data.q}
                         onChange={(e) => setData('q', e.target.value)}
-                        className="flex-1 rounded border border-neutral-300 px-3 py-2"
+                        className="form-input flex-1"
                         placeholder="Search articles…"
                     />
-                    <button type="submit" className="rounded bg-apes-primary px-4 py-2 text-white">
+                    <button type="submit" className="button-primary">
                         Search
                     </button>
                 </form>
                 <ul className="mt-8 space-y-4">
                     {results.map((r) => (
-                        <li key={r.slug}>
-                            <Link href={`/articles/${r.slug}`} className="text-lg font-medium hover:underline">
+                        <li key={r.slug} className="rounded-card border border-border bg-white p-4">
+                            <Link href={`/articles/${r.slug}`} className="text-lg font-bold text-body hover:text-teal-deep hover:underline">
                                 {r.title}
                             </Link>
-                            {r.excerpt && <p className="text-sm text-neutral-600">{r.excerpt}</p>}
+                            {r.excerpt && <p className="mt-1 text-sm text-muted">{r.excerpt}</p>}
                         </li>
                     ))}
                 </ul>

--- a/resources/js/Pages/Staff/Campaigns/Preview.tsx
+++ b/resources/js/Pages/Staff/Campaigns/Preview.tsx
@@ -38,12 +38,12 @@ export default function CampaignPreview({
                     <p className="mt-2 text-sm text-green-700">Test send queued. It cannot trigger a live campaign.</p>
                 )}
 
-                <article className="mt-8 rounded border border-neutral-200 p-6">
-                    <p className="text-sm text-neutral-600">
+                <article className="mt-8 rounded-card border border-border p-6">
+                    <p className="text-sm text-muted">
                         {snapshot.channel_label} · {snapshot.author}
                     </p>
-                    <h2 className="mt-2 text-xl font-semibold">{snapshot.title}</h2>
-                    {snapshot.excerpt && <p className="mt-3 text-neutral-700">{snapshot.excerpt}</p>}
+                    <h2 className="mt-2 text-xl font-bold text-body">{snapshot.title}</h2>
+                    {snapshot.excerpt && <p className="mt-3 text-body">{snapshot.excerpt}</p>}
                     <a href={snapshot.read_more_url} className="mt-4 inline-block text-sm underline">
                         Read the full story
                     </a>
@@ -51,7 +51,7 @@ export default function CampaignPreview({
 
                 <form onSubmit={sendTest} className="mt-8 flex flex-col gap-3 border-t pt-6">
                     <h2 className="font-medium">Test send</h2>
-                    <p className="text-sm text-neutral-600">Enter an explicit recipient. Never pre-filled from live lists.</p>
+                    <p className="text-sm text-muted">Enter an explicit recipient. Never pre-filled from live lists.</p>
                     <input
                         type="email"
                         required

--- a/resources/js/Pages/Staff/Posts/Edit.tsx
+++ b/resources/js/Pages/Staff/Posts/Edit.tsx
@@ -148,12 +148,12 @@ export default function PostEdit({
         <>
             <Head title={isNew ? 'New post' : `Edit: ${post.title}`} />
             <main className="mx-auto max-w-3xl px-6 py-12">
-                <Link href="/staff/posts" className="text-sm text-neutral-600 hover:underline">
+                <Link href="/staff/posts" className="text-sm text-teal-deep hover:underline">
                     ← Posts
                 </Link>
                 <h1 className="mt-4 text-2xl font-semibold">{isNew ? 'New draft' : 'Edit draft'}</h1>
                 {!isNew && (
-                    <p className="mt-1 text-sm text-neutral-600">
+                    <p className="mt-1 text-sm text-muted">
                         Status: {post.status}{' '}
                         <Link href={`/staff/posts/${post.id}/preview`} className="underline">
                             Preview

--- a/resources/js/Pages/Staff/Posts/Index.tsx
+++ b/resources/js/Pages/Staff/Posts/Index.tsx
@@ -18,10 +18,10 @@ function postStatus(status: string) {
         draft: { label: 'Draft', className: 'bg-brand-mist text-teal-deep' },
         in_review: { label: 'In review', className: 'bg-warning-mist text-warning' },
         published: { label: 'Published', className: 'bg-success-mist text-success' },
-        archived: { label: 'Archived', className: 'bg-neutral-100 text-muted' },
+        archived: { label: 'Archived', className: 'bg-page-tint text-muted' },
     };
 
-    return labels[status] ?? { label: status.replaceAll('_', ' '), className: 'bg-neutral-100 text-muted' };
+    return labels[status] ?? { label: status.replaceAll('_', ' '), className: 'bg-page-tint text-muted' };
 }
 
 function formatDate(value: string | null) {
@@ -36,7 +36,7 @@ function StatusBadge({ status }: { status: string }) {
 function ChannelLabel({ value }: { value: string }) {
     const meta = channelMeta(value);
     return (
-        <span className={`inline-flex rounded border border-border px-2 py-1 text-[0.625rem] font-bold tracking-wide uppercase ${meta?.badgeClass ?? 'bg-neutral-100 text-muted'}`}>
+        <span className={`inline-flex rounded border border-border px-2 py-1 text-[0.625rem] font-bold tracking-wide uppercase ${meta?.badgeClass ?? 'bg-page-tint text-muted'}`}>
             {meta?.label ?? value.replaceAll('_', ' ')}
         </span>
     );

--- a/resources/js/Pages/Staff/Posts/Review.tsx
+++ b/resources/js/Pages/Staff/Posts/Review.tsx
@@ -23,7 +23,7 @@ export default function ReviewQueue({ posts }: { posts: Post[] }) {
                     </Link>
                 </div>
                 {posts.length === 0 ? (
-                    <p className="mt-8 text-neutral-600">No posts awaiting review.</p>
+                    <p className="mt-8 text-muted">No posts awaiting review.</p>
                 ) : (
                     <table className="mt-8 w-full text-left text-sm">
                         <thead>

--- a/resources/js/Pages/home.tsx
+++ b/resources/js/Pages/home.tsx
@@ -7,6 +7,38 @@ import PublicLayout from '../Components/Layout/PublicLayout';
 
 type Channel = { slug: string; label: string };
 
+function FeaturedHeroImage({ featured }: { featured: PostCard }) {
+    if (!featured.hero_image) {
+        return (
+            <aside className="mx-auto w-full max-w-sm rounded-feature border border-border bg-page-tint p-8">
+                <ApesLogo
+                    variant="square"
+                    alt="Association for the Protection of Exotic Species"
+                    className="h-auto w-full object-contain"
+                />
+                <div className="mt-8 border-t border-border pt-6 text-center">
+                    <h2 className="text-sm font-bold text-body">Our mission</h2>
+                    <p className="mt-2 text-xs leading-6 text-muted">
+                        Securing a sustainable future for wildlife and communities through science, rescue, and compassionate care.
+                    </p>
+                </div>
+            </aside>
+        );
+    }
+
+    return (
+        <figure className="overflow-hidden rounded-feature border border-border">
+            <img
+                src={featured.hero_image}
+                alt={featured.hero_image_alt ?? featured.title}
+                className="aspect-[4/5] w-full object-cover sm:aspect-[3/4]"
+                loading="eager"
+                decoding="async"
+            />
+        </figure>
+    );
+}
+
 export default function Home({
     featured,
     recent,
@@ -22,27 +54,32 @@ export default function Home({
             <main id="main-content">
                 <section className="border-b border-border bg-white">
                     <div className="mx-auto grid max-w-public items-center gap-12 px-5 py-12 sm:px-6 md:grid-cols-12 md:py-20">
-                    <div className="md:col-span-7">
-                        <DeskPanel featured={featured} />
-                    </div>
-                    <aside className="mx-auto w-full max-w-sm rounded-feature border border-border bg-page-tint p-8 md:col-span-5">
-                        <ApesLogo
-                            variant="square"
-                            alt="Association for the Protection of Exotic Species"
-                            className="h-auto w-full object-contain"
-                        />
-                        <div className="mt-8 border-t border-border pt-6 text-center">
-                            <h2 className="text-sm font-bold text-body">Our mission</h2>
-                            <p className="mt-2 text-xs leading-6 text-muted">
-                                Securing a sustainable future for wildlife and communities through science, rescue, and compassionate care.
-                            </p>
+                        <div className="md:col-span-7">
+                            <DeskPanel featured={featured} />
                         </div>
-                    </aside>
+                        <div className="md:col-span-5">
+                            {featured ? <FeaturedHeroImage featured={featured} /> : (
+                                <aside className="mx-auto w-full max-w-sm rounded-feature border border-border bg-page-tint p-8">
+                                    <ApesLogo
+                                        variant="square"
+                                        alt="Association for the Protection of Exotic Species"
+                                        className="h-auto w-full object-contain"
+                                    />
+                                    <div className="mt-8 border-t border-border pt-6 text-center">
+                                        <h2 className="text-sm font-bold text-body">Our mission</h2>
+                                        <p className="mt-2 text-xs leading-6 text-muted">
+                                            Securing a sustainable future for wildlife and communities through science, rescue, and compassionate care.
+                                        </p>
+                                    </div>
+                                </aside>
+                            )}
+                        </div>
                     </div>
                 </section>
 
                 <section className="py-12 sm:py-16" aria-label="APES newsroom channels">
                     <div className="mx-auto max-w-public px-5 sm:px-6">
+                        <h2 className="sr-only">Newsroom channels</h2>
                         <div className="grid gap-6 md:grid-cols-3">
                             {channels.map((channel) => (
                                 <ChannelTrailTile key={channel.slug} slug={channel.slug} />
@@ -53,14 +90,22 @@ export default function Home({
 
                 <section className="border-t border-border bg-white py-12" aria-labelledby="recent-heading">
                     <div className="mx-auto max-w-public px-5 sm:px-6">
-                    <h2 id="recent-heading" className="text-2xl font-bold text-body">Recent stories</h2>
-                    {recent.length > 0 ? (
-                        <div className="mt-8 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-                            {recent.map((post) => <RecentStoryCard key={post.slug} post={post} />)}
-                        </div>
-                    ) : (
-                        <p className="mt-6 rounded-card border border-border bg-white p-6 text-muted">No additional stories are published yet.</p>
-                    )}
+                        <h2 id="recent-heading" className="text-2xl font-bold text-body">Recent stories</h2>
+                        {recent.length > 0 ? (
+                            <div className="mt-8 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+                                {recent.map((post, index) => (
+                                    <RecentStoryCard
+                                        key={post.slug}
+                                        post={post}
+                                        variant={index === 0 ? 'lead' : 'default'}
+                                    />
+                                ))}
+                            </div>
+                        ) : (
+                            <p className="mt-6 rounded-card border border-border bg-white p-6 text-muted">
+                                No additional stories are published yet.
+                            </p>
+                        )}
                     </div>
                 </section>
             </main>

--- a/resources/js/__tests__/home.test.tsx
+++ b/resources/js/__tests__/home.test.tsx
@@ -7,7 +7,7 @@ import { setMockPage } from '../test/inertia';
 import appCss from '../../css/app.css?raw';
 import protectedEmailSource from '../Components/Layout/ProtectedEmail.tsx?raw';
 
-describe('Direction A public homepage', () => {
+describe('Direction B public homepage', () => {
     let desktopMatches: boolean;
     let desktopChangeListeners: Set<(event: MediaQueryListEvent) => void>;
 
@@ -97,7 +97,9 @@ describe('Direction A public homepage', () => {
             'href',
             '/apes-shelter-rescue',
         );
-        expect(screen.getByRole('heading', { name: 'Wildlife corridor project reaches a new milestone' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Wildlife corridor project reaches a new milestone' })).toHaveClass('display-headline');
+        expect(document.querySelector('.editorial-rule')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /^APES CIC/ })).toHaveClass('channel-block');
         expect(
             screen.getByRole('link', {
                 name: 'Read the story: Wildlife corridor project reaches a new milestone',

--- a/tests/Feature/HomePageTest.php
+++ b/tests/Feature/HomePageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Post;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
@@ -24,5 +25,19 @@ class HomePageTest extends TestCase
                 ->etc())
             ->has('recent')
             ->has('featured'));
+    }
+
+    public function test_homepage_card_payload_includes_hero_image_fields(): void
+    {
+        Post::factory()->published()->create([
+            'hero_image' => 'https://example.test/hero.jpg',
+            'hero_image_alt' => 'A capuchin monkey in habitat',
+        ]);
+
+        $this->get('/')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('featured.hero_image', 'https://example.test/hero.jpg')
+                ->where('featured.hero_image_alt', 'A capuchin monkey in habitat'));
     }
 }


### PR DESCRIPTION
## Summary

- Implements stakeholder-approved Direction B (Magazine Bold Grid): asymmetric homepage hero, bold three-channel entry cards, lead-story editorial grid, and hero image support on cards.
- Adds shared design utilities (display-headline, editorial-rule, channel-block, form-panel, status badges) and new AccountLayout/AuthCard components.
- Migrates public, account/mailing, auth, and workspace surfaces to consistent APES tokens while preserving routes, permissions, and consent behaviour.

## Test plan

- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [x] npm run test:frontend (home.test.tsx)
- [x] phpunit HomePageTest.php
- [x] PHP Pint --test
- [ ] CI green on PR
- [ ] Manual smoke on homepage, article, login, account/mailing after deploy

Closes #53
Relates to #36, #1

Made with [Cursor](https://cursor.com)